### PR TITLE
fix: cannot update while rendering for chess puzzle

### DIFF
--- a/.changeset/nasty-bobcats-rule.md
+++ b/.changeset/nasty-bobcats-rule.md
@@ -1,0 +1,6 @@
+---
+"@react-chess-tools/react-chess-puzzle": patch
+"@react-chess-tools/react-chess-game": patch
+---
+
+fixed Cannot update a component (Root) while rendering a different component (PuzzleRoot) error

--- a/packages/react-chess-game/src/hooks/useChessGame.ts
+++ b/packages/react-chess-game/src/hooks/useChessGame.ts
@@ -31,7 +31,6 @@ export const useChessGame = ({
 
       return true;
     } catch (e) {
-      console.error(e);
       return false;
     }
   };

--- a/packages/react-chess-game/src/index.ts
+++ b/packages/react-chess-game/src/index.ts
@@ -1,2 +1,3 @@
 export { ChessGame } from "./components/ChessGame";
 export { useChessGameContext } from "./hooks/useChessGameContext";
+export { useChessGame } from "./hooks/useChessGame";

--- a/packages/react-chess-puzzle/src/hooks/reducer.ts
+++ b/packages/react-chess-puzzle/src/hooks/reducer.ts
@@ -1,11 +1,11 @@
 import { Chess, Move } from "chess.js";
-import { useChessGame } from "@react-chess-tools/react-chess-game";
-import { getOrientation, type Puzzle, type Hint, type Status } from "../utils";
+import { type Puzzle, type Hint, type Status } from "../utils";
 
 export type State = {
   puzzle: Puzzle;
   currentMoveIndex: number;
   status: Status;
+  cpuMove?: string | null;
   nextMove?: string | null;
   hint: Hint;
   needCpuMove: boolean;
@@ -17,21 +17,14 @@ export type Action =
       type: "INITIALIZE";
       payload: {
         puzzle: Puzzle;
-        setPosition: ReturnType<typeof useChessGame>["methods"]["setPosition"];
       };
     }
   | {
       type: "RESET";
-      payload: {
-        setPosition: ReturnType<typeof useChessGame>["methods"]["setPosition"];
-      };
     }
   | { type: "TOGGLE_HINT" }
   | {
       type: "CPU_MOVE";
-      payload: {
-        makeMove?: ReturnType<typeof useChessGame>["methods"]["makeMove"];
-      };
     }
   | {
       type: "PLAYER_MOVE";
@@ -44,14 +37,7 @@ export type Action =
       };
     };
 
-export const initializePuzzle = ({
-  puzzle,
-  setPosition,
-}: {
-  puzzle: Puzzle;
-  setPosition: ReturnType<typeof useChessGame>["methods"]["setPosition"];
-}): State => {
-  setPosition(puzzle.fen, getOrientation(puzzle));
+export const initializePuzzle = ({ puzzle }: { puzzle: Puzzle }): State => {
   return {
     puzzle,
     currentMoveIndex: 0,
@@ -75,7 +61,6 @@ export const reducer = (state: State, action: Action): State => {
         ...state,
         ...initializePuzzle({
           puzzle: state.puzzle,
-          setPosition: action.payload.setPosition,
         }),
       };
     case "TOGGLE_HINT":
@@ -91,13 +76,10 @@ export const reducer = (state: State, action: Action): State => {
         return state;
       }
 
-      if (state.nextMove) {
-        action.payload.makeMove?.(state.nextMove);
-      }
-
       return {
         ...state,
         currentMoveIndex: state.currentMoveIndex + 1,
+        cpuMove: state.puzzle.moves[state.currentMoveIndex],
         nextMove:
           state.currentMoveIndex < state.puzzle.moves.length - 1
             ? state.puzzle.moves[state.currentMoveIndex + 1]


### PR DESCRIPTION
fixed `Cannot update a component (`Root`) while rendering a different component (`PuzzleRoot`)`

This required to remove all state updates from chess game from the puzzle reducer. They have been replaced with useEffect hooks