### PR TITLE
feature: auto-retry puzzles

### DIFF
--- a/packages/react-chess-game/src/hooks/useChessGame.ts
+++ b/packages/react-chess-game/src/hooks/useChessGame.ts
@@ -60,6 +60,18 @@ export const useChessGame = ({
   const goToPreviousMove = () => goToMove(currentMoveIndex - 1);
   const goToNextMove = () => goToMove(currentMoveIndex + 1);
 
+  const undoMove = (): boolean => {
+    try {
+      const copy = cloneGame(game);
+      copy.undo();
+      setGame(copy);
+      setCurrentMoveIndex(copy.history().length - 1);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  };
+
   return {
     game,
     currentFen: getCurrentFen(fen, game, currentMoveIndex),
@@ -77,6 +89,7 @@ export const useChessGame = ({
       goToEnd,
       goToPreviousMove,
       goToNextMove,
+      undoMove,
     },
   };
 };

--- a/packages/react-chess-puzzle/src/hooks/reducer.ts
+++ b/packages/react-chess-puzzle/src/hooks/reducer.ts
@@ -35,6 +35,12 @@ export type Action =
         changePuzzle: (puzzle: Puzzle) => void;
         game: Chess;
       };
+    }
+  | {
+      type: "AUTO_RETRY";
+      payload: {
+        puzzle: Puzzle;
+      };
     };
 
 export const initializePuzzle = ({ puzzle }: { puzzle: Puzzle }): State => {
@@ -47,6 +53,22 @@ export const initializePuzzle = ({ puzzle }: { puzzle: Puzzle }): State => {
     cpuMove: null,
     needCpuMove: !!puzzle.makeFirstMove,
     isPlayerTurn: !puzzle.makeFirstMove,
+  };
+};
+
+export const autoRetryPuzzle = (
+  { puzzle }: { puzzle: Puzzle },
+  currentMove: number,
+): State => {
+  return {
+    puzzle,
+    currentMoveIndex: currentMove,
+    status: "in-progress",
+    nextMove: puzzle.moves[currentMove],
+    hint: "none",
+    cpuMove: null,
+    needCpuMove: false,
+    isPlayerTurn: true,
   };
 };
 
@@ -134,6 +156,13 @@ export const reducer = (state: State, action: Action): State => {
         status: "in-progress",
         needCpuMove: true,
         isPlayerTurn: false,
+      };
+    }
+
+    case "AUTO_RETRY": {
+      return {
+        ...state,
+        ...autoRetryPuzzle(action.payload, state.currentMoveIndex),
       };
     }
 

--- a/packages/react-chess-puzzle/src/hooks/useChessPuzzle.ts
+++ b/packages/react-chess-puzzle/src/hooks/useChessPuzzle.ts
@@ -15,6 +15,7 @@ export const useChessPuzzle = (
   const {
     game,
     methods: { makeMove, setPosition },
+    currentFen,
   } = gameContext;
 
   useEffect(() => {
@@ -26,6 +27,10 @@ export const useChessPuzzle = (
   const changePuzzle = (puzzle: Puzzle) => {
     dispatch({ type: "INITIALIZE", payload: { puzzle } });
     setPosition(puzzle.fen, getOrientation(puzzle));
+  };
+
+  const autoRetry = () => {
+    dispatch({ type: "AUTO_RETRY", payload: { puzzle } });
   };
 
   useEffect(() => {
@@ -79,6 +84,8 @@ export const useChessPuzzle = (
   return {
     status: state.status,
     changePuzzle,
+    autoRetry,
+    currentMoveIndex: state.currentMoveIndex,
     puzzle,
     hint: state.hint,
     onHint,


### PR DESCRIPTION
PR to auto retry puzzles:
Instead of user's having to restart the entire puzzle everytime they get a move wrong, they can use this auto retry function to automatically reset the puzzle back one move. 

You can implement this with: 

`function AutoRetryHandler() {
  const { status, autoRetry } = useChessPuzzleContext();
  const { methods } = useChessGameContext();

  useEffect(() => {
    if (status === 'failed') {
      setTimeout(() => {
        console.log("Calling undoMove()");
        autoRetry();
        methods.undoMove();
      }, 1000); // 1 second delay for user to see incorrect move
    }
  }, [status]);

  return null;
}`

`<ChessPuzzle.Root puzzle={puzzle}>
            {/* Only render Sounds component when enabled */}
            {soundsEnabled && <ChessGame.Sounds />}
            <ChessGame.KeyboardControls />
            <ChessPuzzle.Board />
            
            {/* Add the auto-retry handler */}
            <AutoRetryHandler />
            ...`
            
We could also just call the autoRetry and undoMove functions automatically upon puzzle failure from within the `react-chess-puzzle` package if we wanted to have it be the default behavior and not need the custom `AutoRetry` function defined in the app code.