### PR TITLE
feat: pass puzzleContext to onSolve and onFail callbacks

### DIFF
--- a/.changeset/thick-cooks-sneeze.md
+++ b/.changeset/thick-cooks-sneeze.md
@@ -1,5 +1,5 @@
 ---
-"@react-chess-tools/react-chess-puzzle": major
+"@react-chess-tools/react-chess-puzzle": minor
 ---
 
 Pass the whole puzzle context to onSolve and onFail callbacks

--- a/.changeset/thick-cooks-sneeze.md
+++ b/.changeset/thick-cooks-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@react-chess-tools/react-chess-puzzle": major
+---
+
+Pass the whole puzzle context to onSolve and onFail callbacks

--- a/packages/react-chess-puzzle/README.MD
+++ b/packages/react-chess-puzzle/README.MD
@@ -1,4 +1,5 @@
 <div align="center">
+    <h1>react-chess-puzzle</h1>
     A lightweight, customizable React component library for rendering and interacting with chess puzzles.
 </div>
 
@@ -26,11 +27,35 @@ To use the `react-chess-puzzle` package, you can import the `ChessPuzzle` compon
 import { ChessPuzzle } from "@react-chess-tools/react-chess-puzzle";
 
 const App = () => {
-  <ChessPuzzle.Root puzzle={...}>
-    <ChessPuzzle.Board />
-  </ChessPuzzle.Root>;
+  const puzzle = {
+    fen: "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+    moves: ["d2d4", "e5d4", "f3d4"],
+    makeFirstMove: false,
+  };
+
+  return (
+    <ChessPuzzle.Root puzzle={puzzle}>
+      <ChessPuzzle.Board />
+      <div className="controls">
+        <ChessPuzzle.Reset>Restart Puzzle</ChessPuzzle.Reset>
+        <ChessPuzzle.Hint showOn={["in-progress"]}>Get Hint</ChessPuzzle.Hint>
+      </div>
+    </ChessPuzzle.Root>
+  );
 };
 ```
+
+## Puzzle Solving Flow
+
+The puzzle-solving flow follows these steps:
+
+1. **Initial Setup**: The board is set up using the provided FEN string
+2. **First Move**: If `makeFirstMove` is `true`, the component automatically makes the first move in the solution sequence
+3. **User Interaction**: The user attempts to solve the puzzle by making the correct moves
+4. **Feedback**: The component validates each move and provides feedback:
+   - If the move is correct, the puzzle continues
+   - If the move is incorrect, the puzzle is marked as failed
+5. **Completion**: When all correct moves have been made, the puzzle is marked as solved
 
 ## Documentation
 
@@ -38,38 +63,130 @@ The `react-chess-puzzle` package provides a set of components that you can use t
 
 ### ChessPuzzle.Root
 
-The `ChessPuzzle.Root` component is the root component of the `react-chess-puzzle` package. It is used to provide the `ChessPuzzleContext` to the rest of the components. It accept a `puzzle` prop that is used to instantiate the puzzle.
+The `ChessPuzzle.Root` component is the root component of the `react-chess-puzzle` package. It is used to provide the `ChessPuzzleContext` to the rest of the components. It accepts a `puzzle` prop that is used to instantiate the puzzle.
 
 #### Props
 
 The `ChessPuzzle.Root` component accepts the following props:
 
-| Name        | Type        | Default | Description                 |
-| ----------- | ----------- | ------- | --------------------------- |
-| `puzzle`    | `Puzzle`    |         | The puzzle to be solved     |
-| `children?` | `ReactNode` |         | The children to be rendered |
+| Name        | Type                                              | Default     | Description                                                                                                          |
+| ----------- | ------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------- |
+| `puzzle`    | `Puzzle`                                          |             | The puzzle to be solved                                                                                              |
+| `onSolve`   | `(puzzleContext: ChessPuzzleContextType) => void` | `undefined` | Callback function that is triggered when the puzzle is successfully solved, receives the puzzle context as parameter |
+| `onFail`    | `(puzzleContext: ChessPuzzleContextType) => void` | `undefined` | Callback function that is triggered when an incorrect move is played, receives the puzzle context as parameter       |
+| `children?` | `ReactNode`                                       |             | The children to be rendered                                                                                          |
 
-the `puzzle` prop contains the following properties:
+The `puzzle` prop contains the following properties:
 
 | Name            | Type       | Default | Description                                                                |
 | --------------- | ---------- | ------- | -------------------------------------------------------------------------- |
-| `fen`           | `string`   |         | The FEN string of the puzzle                                               |
-| `moves`         | `string[]` |         | The moves of the puzzle                                                    |
+| `fen`           | `string`   |         | The FEN string representing the initial position of the puzzle             |
+| `moves`         | `string[]` |         | The sequence of moves (in algebraic notation) that solve the puzzle        |
 | `makeFirstMove` | `boolean`  | `false` | Whether the first move is part of the problem or must be played by the CPU |
 
 ### ChessPuzzle.Board
 
 The `ChessPuzzle.Board` component is used to render the chess board. It is a wrapper around the `ChessGame.Board` component and accepts the same props.
 
-### Using react-chess-game Components
+#### Props
 
-Since `react-chess-puzzle` is built on top of `react-chess-game`, you can use any of its components within your puzzle interface. This includes:
+Inherits all props from `ChessGame.Board` with these additional options:
 
-- `ChessGame.Sounds` - Add sound effects for moves/captures
-- `ChessGame.KeyboardControls` - Add keyboard navigation
-- `useChessGameContext` - Access game state and methods
+| Name             | Type                 | Default   | Description                                  |
+| ---------------- | -------------------- | --------- | -------------------------------------------- |
+| `showHighlights` | `boolean`            | `true`    | Show highlights for legal moves on the board |
+| `orientation`    | `"white" \| "black"` | `"white"` | Board orientation                            |
 
-Example usage with sounds and keyboard controls:
+### ChessPuzzle.Reset
+
+A button component that resets the current puzzle or loads a new one.
+
+#### Props
+
+| Name      | Type                  | Default                                              | Description                                                                                                                                                                                                   |
+| --------- | --------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `puzzle`  | `Puzzle \| undefined` | `undefined`                                          | The puzzle object for a new puzzle. If not provided, the current puzzle is reset.                                                                                                                             |
+| `onReset` | `() => void`          | `undefined`                                          | A callback function that is called when the puzzle is reset.                                                                                                                                                  |
+| `showOn`  | `PuzzleState[]`       | `["not-started", "in-progress", "solved", "failed"]` | The state(s) in which the button is shown. Valid states are: "not-started", "in-progress", "solved", "failed"                                                                                                 |
+| `asChild` | `boolean`             | `false`                                              | Change the component to the HTML tag or custom component of the only child. This will merge the original component props with the props of the supplied element/component and change the underlying DOM node. |
+
+### ChessPuzzle.Hint
+
+A button component that provides a hint by highlighting the next move in the solution.
+
+#### Props
+
+| Name      | Type            | Default           | Description                                                                                                                                                                                                   |
+| --------- | --------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `showOn`  | `PuzzleState[]` | `["in-progress"]` | The state(s) in which the button is shown. Valid states are: "not-started", "in-progress", "solved", "failed"                                                                                                 |
+| `asChild` | `boolean`       | `false`           | Change the component to the HTML tag or custom component of the only child. This will merge the original component props with the props of the supplied element/component and change the underlying DOM node. |
+
+## Hooks and Context
+
+### useChessPuzzleContext
+
+A hook that provides access to the puzzle state and methods.
+
+```tsx
+import { useChessPuzzleContext } from "@react-chess-tools/react-chess-puzzle";
+
+const MyComponent = () => {
+  const {
+    puzzleState, // "not-started" | "in-progress" | "solved" | "failed"
+    resetPuzzle, // Function to reset the current puzzle
+    showHint, // Function to show a hint
+    movesPlayed, // Number of moves played so far
+    totalMoves, // Total number of moves in the solution
+  } = useChessPuzzleContext();
+
+  return (
+    <div>
+      <p>Puzzle state: {puzzleState}</p>
+      <p>
+        Progress: {movesPlayed}/{totalMoves} moves
+      </p>
+      <button onClick={resetPuzzle}>Reset</button>
+    </div>
+  );
+};
+```
+
+### useChessGameContext
+
+Since `react-chess-puzzle` is built on top of `react-chess-game`, you can also use the `useChessGameContext` hook to access the underlying game state and methods.
+
+```tsx
+import { useChessGameContext } from "@react-chess-tools/react-chess-game";
+
+const MyComponent = () => {
+  const {
+    fen, // Current FEN string
+    gameState, // Game state (playing, checkmate, etc.)
+    turn, // Current turn ("w" | "b")
+    moves, // List of legal moves
+    makeMove, // Function to make a move
+    history, // Game move history
+    selectedSquare, // Currently selected square
+    setSelectedSquare, // Function to select a square
+    checkSquare, // Square with the king in check (if any)
+  } = useChessGameContext();
+
+  return (
+    <div>
+      <p>Current FEN: {fen}</p>
+      <p>Current turn: {turn === "w" ? "White" : "Black"}</p>
+    </div>
+  );
+};
+```
+
+## Using react-chess-game Components
+
+Since `react-chess-puzzle` is built on top of `react-chess-game`, you can use any of its components within your puzzle interface:
+
+### ChessGame.Sounds
+
+Add sound effects for moves, captures, and other chess events.
 
 ```tsx
 import { ChessPuzzle } from "@react-chess-tools/react-chess-puzzle";
@@ -78,35 +195,128 @@ import { ChessGame } from "@react-chess-tools/react-chess-game";
 const App = () => (
   <ChessPuzzle.Root puzzle={...}>
     <ChessGame.Sounds />
+    <ChessPuzzle.Board />
+  </ChessPuzzle.Root>
+);
+```
+
+### ChessGame.KeyboardControls
+
+Add keyboard navigation for accessible play.
+
+```tsx
+import { ChessPuzzle } from "@react-chess-tools/react-chess-puzzle";
+import { ChessGame } from "@react-chess-tools/react-chess-game";
+
+const App = () => (
+  <ChessPuzzle.Root puzzle={...}>
     <ChessGame.KeyboardControls />
     <ChessPuzzle.Board />
   </ChessPuzzle.Root>
 );
 ```
 
-### `Puzzle.Reset`
+## Complete Example
 
-A button that changes the puzzle. It can be used, for example, to restart the puzzle or move to the next puzzle.
+Here's a complete example of a chess puzzle component with sounds, keyboard controls, and custom styling:
 
-#### Props
+```tsx
+import { ChessPuzzle } from "@react-chess-tools/react-chess-puzzle";
+import { ChessGame } from "@react-chess-tools/react-chess-game";
+import { useState } from "react";
+import "./ChessPuzzleStyles.css"; // Your custom CSS
 
-| Name      | Type                                                       | Default | Description                                                                                                                                                                                                   |
-| --------- | ---------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `puzzle`  | `Puzzle`                                                   |         | The puzzle object containing the FEN string and moves sequence. If not provided, the current puzzle is reset.                                                                                                 |
-| `onReset` | `() => void`                                               |         | A callback function that is called when the puzzle is reset.                                                                                                                                                  |
-| `showOn`  | `"not-started" \| "in-progress" \| "solved" \| "failed"[]` |         | The state(s) in which the button is shown.                                                                                                                                                                    |
-| `asChild` | `boolean`                                                  | `false` | Change the component to the HTML tag or custom component of the only child. This will merge the original component props with the props of the supplied element/component and change the underlying DOM node. |
+export const PuzzleSolver = () => {
+  // Example puzzles
+  const puzzles = [
+    {
+      fen: "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
+      moves: ["d2d4", "e5d4", "f3d4"],
+      makeFirstMove: false,
+    },
+    {
+      fen: "r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4",
+      moves: ["f3g5", "d7d5", "e4d5", "c6a5"],
+      makeFirstMove: false,
+    },
+  ];
 
-### `Puzzle.Hint`
+  const [currentPuzzle, setCurrentPuzzle] = useState(0);
+  const [score, setScore] = useState(0);
 
-A button that shows the next move of the puzzle.
+  // Function to load the next puzzle
+  const nextPuzzle = () => {
+    setCurrentPuzzle((prev) => (prev + 1) % puzzles.length);
+  };
 
-#### Props
+  const handleSolve = (puzzleContext) => {
+    setScore((prev) => prev + 10);
+    console.log(`Puzzle solved in ${puzzleContext.movesPlayed} moves`);
+    // Could automatically progress to next puzzle
+    // setTimeout(nextPuzzle, 1500);
+  };
 
-| Name      | Type                                                       | Default | Description                                                                                                                                                                                                   |
-| --------- | ---------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `showOn`  | `"not-started" \| "in-progress" \| "solved" \| "failed"[]` |         | The state(s) in which the button is shown.                                                                                                                                                                    |
-| `asChild` | `boolean`                                                  | `false` | Change the component to the HTML tag or custom component of the only child. This will merge the original component props with the props of the supplied element/component and change the underlying DOM node. |
+  const handleFail = (puzzleContext) => {
+    setScore((prev) => Math.max(0, prev - 5));
+    console.log(`Failed move: ${puzzleContext.lastMove}`);
+  };
+
+  return (
+    <div className="puzzle-container">
+      <div className="score">Score: {score}</div>
+      <ChessPuzzle.Root
+        puzzle={puzzles[currentPuzzle]}
+        onSolve={handleSolve}
+        onFail={handleFail}
+      >
+        <ChessGame.Sounds />
+        <ChessGame.KeyboardControls />
+
+        <div className="board-container">
+          <ChessPuzzle.Board />
+        </div>
+
+        <div className="controls">
+          <PuzzleStatus />
+          <div className="buttons">
+            <ChessPuzzle.Reset>Restart</ChessPuzzle.Reset>
+            <ChessPuzzle.Hint showOn={["in-progress"]}>Hint</ChessPuzzle.Hint>
+            <ChessPuzzle.Reset
+              puzzle={puzzles[(currentPuzzle + 1) % puzzles.length]}
+              onReset={nextPuzzle}
+            >
+              Next Puzzle
+            </ChessPuzzle.Reset>
+          </div>
+        </div>
+      </ChessPuzzle.Root>
+    </div>
+  );
+};
+
+// Custom component using the context
+const PuzzleStatus = () => {
+  const { puzzleState, movesPlayed, totalMoves } = useChessPuzzleContext();
+
+  let message = "";
+  switch (puzzleState) {
+    case "not-started":
+      message = "Make your move to start the puzzle";
+      break;
+    case "in-progress":
+      message = `Progress: ${movesPlayed}/${totalMoves} moves`;
+      break;
+    case "solved":
+      message = "Puzzle solved! Well done!";
+      break;
+    case "failed":
+      message = "Incorrect move. Try again!";
+      break;
+  }
+
+  return <div className={`status ${puzzleState}`}>{message}</div>;
+};
+```
 
 ## 📝 License
 

--- a/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/Root.tsx
+++ b/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/Root.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import { Puzzle, getOrientation } from "../../../utils";
-import { useChessPuzzle } from "../../../hooks/useChessPuzzle";
+import {
+  ChessPuzzleContextType,
+  useChessPuzzle,
+} from "../../../hooks/useChessPuzzle";
 import { ChessGame } from "@react-chess-tools/react-chess-game";
 import { ChessPuzzleContext } from "../../../hooks/useChessPuzzleContext";
 
 export interface RootProps {
   puzzle: Puzzle;
-  onSolve?: (changePuzzle: (puzzle: Puzzle) => void) => void;
-  onFail?: (changePuzzle: (puzzle: Puzzle) => void) => void;
+  onSolve?: (puzzleContext: ChessPuzzleContextType) => void;
+  onFail?: (puzzleContext: ChessPuzzleContextType) => void;
 }
 
 const PuzzleRoot: React.FC<React.PropsWithChildren<RootProps>> = ({

--- a/packages/react-chess-puzzle/src/hooks/reducer.ts
+++ b/packages/react-chess-puzzle/src/hooks/reducer.ts
@@ -1,5 +1,6 @@
 import { Chess, Move } from "chess.js";
 import { type Puzzle, type Hint, type Status } from "../utils";
+import { ChessPuzzleContextType } from "./useChessPuzzle";
 
 export type State = {
   puzzle: Puzzle;
@@ -30,9 +31,9 @@ export type Action =
       type: "PLAYER_MOVE";
       payload: {
         move?: Move | null;
-        onSolve?: (changePuzzle: (puzzle: Puzzle) => void) => void;
-        onFail?: (changePuzzle: (puzzle: Puzzle) => void) => void;
-        changePuzzle: (puzzle: Puzzle) => void;
+        onSolve?: (puzzleContext: ChessPuzzleContextType) => void;
+        onFail?: (puzzleContext: ChessPuzzleContextType) => void;
+        puzzleContext: ChessPuzzleContextType;
         game: Chess;
       };
     };
@@ -91,7 +92,7 @@ export const reducer = (state: State, action: Action): State => {
       };
 
     case "PLAYER_MOVE": {
-      const { move, onSolve, onFail, changePuzzle } = action.payload;
+      const { move, onSolve, onFail, puzzleContext } = action.payload;
 
       const isMoveRight = [move?.san, move?.lan].includes(
         state?.nextMove || "",
@@ -101,7 +102,7 @@ export const reducer = (state: State, action: Action): State => {
 
       if (!isMoveRight) {
         if (onFail) {
-          onFail(changePuzzle);
+          onFail(puzzleContext);
         }
         return {
           ...state,
@@ -114,7 +115,7 @@ export const reducer = (state: State, action: Action): State => {
 
       if (isPuzzleSolved) {
         if (onSolve) {
-          onSolve(changePuzzle);
+          onSolve(puzzleContext);
         }
 
         return {


### PR DESCRIPTION
## Feat: Pass Full Puzzle Context to Callbacks and Improve Documentation

**Type:** Feature (with Breaking Change)

**Summary:**

This PR introduces a significant enhancement to the `react-chess-puzzle` component, providing more comprehensive information within the `onSolve` and `onFail` callbacks. It also includes substantial documentation improvements for better usability.

**Changes:**

1.  **Enhanced Callbacks (`onSolve`, `onFail`):**
    * Previously, the `onSolve` and `onFail` callbacks passed to `ChessPuzzle.Root` only received the `changePuzzle` function as an argument.
    * This has been changed to pass the *entire* `ChessPuzzleContextType` object. This object includes the puzzle's `status`, the `puzzle` object itself, `hint` state, `nextMove`, `isPlayerTurn`, and the `changePuzzle` function.
    * This provides developers with much richer context within these callbacks, allowing for more complex logic based on the puzzle's state when it's solved or failed.
    * Affected files: `Root.tsx`, `reducer.ts`, `useChessPuzzle.ts`.

2.  **🚨 Breaking Change:**
    * The signature of the `onSolve` and `onFail` props on `ChessPuzzle.Root` has changed.
    * **Before:** `(changePuzzle: (puzzle: Puzzle) => void) => void`
    * **After:** `(puzzleContext: ChessPuzzleContextType) => void`
    * Users of this library will need to update their `onSolve` and `onFail` function implementations to accept the new `puzzleContext` object.

3.  **Documentation Improvements:**
    * Significantly updated and expanded the `README.MD`.
    * Added:
        * A clearer initial example.
        * Explanation of the puzzle-solving flow.
        * Updated documentation for `ChessPuzzle.Root` reflecting the new callback signature.
        * Documentation for `ChessPuzzle.Board`, `ChessPuzzle.Reset`, and `ChessPuzzle.Hint` components.
        * Explanation and examples for `useChessPuzzleContext` and `useChessGameContext`.
        * Clarified usage of underlying `react-chess-game` components.
        * A new comprehensive example demonstrating various features (`Sounds`, `KeyboardControls`, custom status display, `onSolve`/`onFail` usage).

4.  **Release Management:**
    * Added a changeset file (`.changeset/thick-cooks-sneeze.md`) to mark this as a `major` version bump for the `@react-chess-tools/react-chess-puzzle` package, reflecting the breaking change introduced.

**Motivation:**

Passing the full context to the callbacks makes the library more flexible and powerful, enabling developers to react more dynamically to puzzle completion or failure without needing to manage separate state related to the puzzle's context. The documentation improvements aim to make the library easier to understand and integrate.