### PR TITLE
feat: export missing TypeScript types and component props

### DIFF
--- a/.changeset/few-feet-develop.md
+++ b/.changeset/few-feet-develop.md
@@ -1,0 +1,6 @@
+---
+"@react-chess-tools/react-chess-puzzle": patch
+"@react-chess-tools/react-chess-game": patch
+---
+
+export missing TypeScript types and component props

--- a/packages/react-chess-game/src/index.ts
+++ b/packages/react-chess-game/src/index.ts
@@ -1,3 +1,22 @@
+// Components
 export { ChessGame } from "./components/ChessGame";
+
+// Hooks & Context
 export { useChessGameContext } from "./hooks/useChessGameContext";
 export { useChessGame } from "./hooks/useChessGame";
+export type { ChessGameContextType } from "./hooks/useChessGameContext";
+export type { useChessGameProps } from "./hooks/useChessGame";
+
+// Audio Types
+export type { Sound, Sounds } from "./assets/sounds";
+export type { SoundsProps } from "./components/ChessGame/parts/Sounds";
+
+// Keyboard Types
+export type { KeyboardControls } from "./components/ChessGame/parts/KeyboardControls";
+
+// Utility Types
+export type { GameInfo } from "./utils/chess";
+
+// Component Props
+export type { ChessGameProps } from "./components/ChessGame/parts/Board";
+export type { RootProps } from "./components/ChessGame/parts/Root";

--- a/packages/react-chess-puzzle/src/index.ts
+++ b/packages/react-chess-puzzle/src/index.ts
@@ -1,2 +1,15 @@
+// Components
 export { ChessPuzzle } from "./components/ChessPuzzle";
+
+// Hooks & Context
 export { useChessPuzzleContext } from "./hooks/useChessPuzzleContext";
+export type { ChessPuzzleContextType } from "./hooks/useChessPuzzle";
+
+// Core Types
+export type { Status, Hint, Puzzle } from "./utils";
+
+// Component Props
+export type { HintProps } from "./components/ChessPuzzle/parts/Hint";
+export type { ResetProps } from "./components/ChessPuzzle/parts/Reset";
+export type { PuzzleBoardProps } from "./components/ChessPuzzle/parts/PuzzleBoard";
+export type { RootProps } from "./components/ChessPuzzle/parts/Root";


### PR DESCRIPTION
## Summary
- Exports ChessPuzzleContextType and other missing TypeScript types
- Exports component props interfaces for ChessGame and ChessPuzzle
- Adds hook exports for better TypeScript integration

## Fixes
Closes #20

## Test plan
- [x] Types are properly exported from package entry points
- [x] TypeScript consumers can import needed types without errors