### PR TITLE
Fix state management and lifecycle issues in chess components

### DIFF
--- a/.changeset/quiet-chicken-draw.md
+++ b/.changeset/quiet-chicken-draw.md
@@ -1,0 +1,6 @@
+---
+"@react-chess-tools/react-chess-game": patch
+"@react-chess-tools/react-chess-puzzle": patch
+---
+
+fix: fix state management and lifecycle issues in chess components

--- a/packages/react-chess-game/src/hooks/useChessGame.ts
+++ b/packages/react-chess-game/src/hooks/useChessGame.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Chess, Color } from "chess.js";
 import { cloneGame, getCurrentFen, getGameInfo } from "../utils/chess";
 
@@ -12,6 +12,11 @@ export const useChessGame = ({
   orientation: initialOrientation,
 }: useChessGameProps = {}) => {
   const [game, setGame] = React.useState(new Chess(fen));
+
+  useEffect(() => {
+    setGame(new Chess(fen));
+  }, [fen]);
+
   const [orientation, setOrientation] = React.useState<Color>(
     initialOrientation ?? "w",
   );
@@ -30,7 +35,7 @@ export const useChessGame = ({
 
   const currentFen = React.useMemo(
     () => getCurrentFen(fen, game, currentMoveIndex),
-    [fen, game, currentMoveIndex],
+    [game, currentMoveIndex],
   );
 
   const currentPosition = React.useMemo(

--- a/packages/react-chess-game/src/utils/chess.ts
+++ b/packages/react-chess-game/src/utils/chess.ts
@@ -104,6 +104,7 @@ export const getCurrentFen = (
     }
   } else {
     const moves = game.history().slice(0, currentMoveIndex + 1);
+
     if (fen) {
       tempGame.load(fen);
     }

--- a/packages/react-chess-puzzle/README.MD
+++ b/packages/react-chess-puzzle/README.MD
@@ -230,42 +230,47 @@ export const PuzzleSolver = () => {
   // Example puzzles
   const puzzles = [
     {
-      fen: "r1bqkbnr/pppp1ppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3",
-      moves: ["d2d4", "e5d4", "f3d4"],
+      fen: "4kb1r/p2r1ppp/4qn2/1B2p1B1/4P3/1Q6/PPP2PPP/2KR4 w k - 0 1",
+      moves: ["Bxd7+", "Nxd7", "Qb8+", "Nxb8", "Rd8#"],
       makeFirstMove: false,
     },
     {
-      fen: "r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4",
-      moves: ["f3g5", "d7d5", "e4d5", "c6a5"],
-      makeFirstMove: false,
+      fen: "6k1/5p1p/p1q1p1p1/1pB1P3/1Pr3Pn/P4P1P/4Q3/3R2K1 b - - 0 31",
+      moves: ["h4f3", "e2f3", "c4c5", "d1d8", "g8g7", "f3f6"],
+      makeFirstMove: true,
     },
   ];
 
   const [currentPuzzle, setCurrentPuzzle] = useState(0);
   const [score, setScore] = useState(0);
 
-  // Function to load the next puzzle
   const nextPuzzle = () => {
-    setCurrentPuzzle((prev) => (prev + 1) % puzzles.length);
+    const nextPuzzle = (currentPuzzle + 1) % puzzles.length;
+    setCurrentPuzzle(nextPuzzle);
   };
 
-  const handleSolve = (puzzleContext) => {
+  const handleSolve = (puzzleContext: ChessPuzzleContextType) => {
     setScore((prev) => prev + 10);
     console.log(`Puzzle solved in ${puzzleContext.movesPlayed} moves`);
-    // Could automatically progress to next puzzle
-    // setTimeout(nextPuzzle, 1500);
+    nextPuzzle();
   };
 
-  const handleFail = (puzzleContext) => {
+  const handleFail = (puzzleContext: ChessPuzzleContextType) => {
     setScore((prev) => Math.max(0, prev - 5));
-    console.log(`Failed move: ${puzzleContext.lastMove}`);
+    console.log(`Puzzle failed in ${puzzleContext.movesPlayed} moves`);
+
+    nextPuzzle();
+  };
+
+  const handleReset = (puzzleContext: ChessPuzzleContextType) => {
+    puzzleContext.changePuzzle(puzzles[currentPuzzle]!);
   };
 
   return (
     <div className="puzzle-container">
       <div className="score">Score: {score}</div>
       <ChessPuzzle.Root
-        puzzle={puzzles[currentPuzzle]}
+        puzzle={puzzles[currentPuzzle]!}
         onSolve={handleSolve}
         onFail={handleFail}
       >
@@ -277,13 +282,12 @@ export const PuzzleSolver = () => {
         </div>
 
         <div className="controls">
-          <PuzzleStatus />
           <div className="buttons">
             <ChessPuzzle.Reset>Restart</ChessPuzzle.Reset>
             <ChessPuzzle.Hint showOn={["in-progress"]}>Hint</ChessPuzzle.Hint>
             <ChessPuzzle.Reset
               puzzle={puzzles[(currentPuzzle + 1) % puzzles.length]}
-              onReset={nextPuzzle}
+              onReset={handleReset}
             >
               Next Puzzle
             </ChessPuzzle.Reset>

--- a/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/Reset.tsx
+++ b/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/Reset.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { isClickableElement, type Puzzle, type Status } from "../../../utils";
-import { useChessPuzzleContext } from "../../..";
+import { useChessPuzzleContext, type ChessPuzzleContextType } from "../../..";
 
 export interface ResetProps {
   asChild?: boolean;
   puzzle?: Puzzle;
-  onReset?: () => void;
+  onReset?: (puzzleContext: ChessPuzzleContextType) => void;
   showOn?: Status[];
 }
 
@@ -25,7 +25,7 @@ export const Reset: React.FC<React.PropsWithChildren<ResetProps>> = ({
   const { changePuzzle, status } = puzzleContext;
   const handleClick = () => {
     changePuzzle(puzzle || puzzleContext.puzzle);
-    onReset?.();
+    onReset?.(puzzleContext);
   };
 
   if (!showOn.includes(status)) {

--- a/packages/react-chess-puzzle/src/hooks/__tests__/reducer.test.ts
+++ b/packages/react-chess-puzzle/src/hooks/__tests__/reducer.test.ts
@@ -27,6 +27,8 @@ describe("reducer", () => {
     cpuMove: null,
     needCpuMove: false,
     isPlayerTurn: true,
+    onSolveInvoked: false,
+    onFailInvoked: false,
   };
 
   describe("initializePuzzle", () => {
@@ -42,6 +44,8 @@ describe("reducer", () => {
         cpuMove: null,
         needCpuMove: false,
         isPlayerTurn: true,
+        onSolveInvoked: false,
+        onFailInvoked: false,
       });
     });
 

--- a/packages/react-chess-puzzle/src/hooks/__tests__/reducer.test.ts
+++ b/packages/react-chess-puzzle/src/hooks/__tests__/reducer.test.ts
@@ -186,15 +186,11 @@ describe("reducer", () => {
 
     it("should handle correct player move", () => {
       const move = { san: "e4", lan: "e2e4" } as Move;
-      const onSolve = jest.fn();
-      const onFail = jest.fn();
 
       const action: Action = {
         type: "PLAYER_MOVE",
         payload: {
           move,
-          onSolve,
-          onFail,
           puzzleContext: mockContext,
           game,
         },
@@ -208,21 +204,15 @@ describe("reducer", () => {
       expect(newState.needCpuMove).toBe(true);
       expect(newState.isPlayerTurn).toBe(false);
       expect(newState.status).toBe("in-progress");
-      expect(onSolve).not.toHaveBeenCalled();
-      expect(onFail).not.toHaveBeenCalled();
     });
 
     it("should handle incorrect player move", () => {
       const move = { san: "d4", lan: "d2d4" } as Move;
-      const onSolve = jest.fn();
-      const onFail = jest.fn();
 
       const action: Action = {
         type: "PLAYER_MOVE",
         payload: {
           move,
-          onSolve,
-          onFail,
           puzzleContext: mockContext,
           game,
         },
@@ -234,14 +224,10 @@ describe("reducer", () => {
       expect(newState.nextMove).toBe(null);
       expect(newState.hint).toBe("none");
       expect(newState.isPlayerTurn).toBe(false);
-      expect(onFail).toHaveBeenCalledWith(mockContext);
-      expect(onSolve).not.toHaveBeenCalled();
     });
 
     it("should handle solving the puzzle", () => {
       const move = { san: "Bb5", lan: "f1b5" } as Move;
-      const onSolve = jest.fn();
-      const onFail = jest.fn();
 
       const lastMoveState: State = {
         ...initialState,
@@ -253,8 +239,6 @@ describe("reducer", () => {
         type: "PLAYER_MOVE",
         payload: {
           move,
-          onSolve,
-          onFail,
           puzzleContext: mockContext,
           game,
         },
@@ -266,20 +250,13 @@ describe("reducer", () => {
       expect(newState.nextMove).toBe(null);
       expect(newState.hint).toBe("none");
       expect(newState.isPlayerTurn).toBe(false);
-      expect(onSolve).toHaveBeenCalledWith(mockContext);
-      expect(onFail).not.toHaveBeenCalled();
     });
 
     it("should handle null move", () => {
-      const onSolve = jest.fn();
-      const onFail = jest.fn();
-
       const action: Action = {
         type: "PLAYER_MOVE",
         payload: {
           move: null,
-          onSolve,
-          onFail,
           puzzleContext: mockContext,
           game,
         },
@@ -288,8 +265,6 @@ describe("reducer", () => {
       const newState = reducer(initialState, action);
 
       expect(newState.status).toBe("failed");
-      expect(onFail).toHaveBeenCalledWith(mockContext);
-      expect(onSolve).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fix fen dependency management in useChessGame hook to prevent stale game state
- Improve puzzle state management by properly handling onSolve/onFail callbacks through useEffect
- Add proper reset functionality with context parameter support in Reset component  
- Update README examples with better TypeScript usage and puzzle configurations
- Add state tracking to prevent duplicate callback invocations

## Test plan
- [x] Verify game state updates correctly when fen prop changes
- [x] Test puzzle callbacks are invoked correctly without duplicates
- [x] Confirm reset functionality works with new context parameter
- [x] Validate README examples compile and run correctly

Resolves #24 #25 #26 #27