### PR TITLE
fix: improve error messages for context hook usage

### DIFF
--- a/packages/react-chess-game/src/hooks/useChessGameContext.ts
+++ b/packages/react-chess-game/src/hooks/useChessGameContext.ts
@@ -9,7 +9,8 @@ export const useChessGameContext = () => {
   const context = React.useContext(ChessGameContext);
   if (!context) {
     throw new Error(
-      "useChessGameContext must be used within a ChessGameProvider",
+      "useChessGameContext must be used within a ChessGame component. " +
+        "Make sure your component is wrapped with <ChessGame.Root> or ensure the ChessGame component is properly rendered in the component tree.",
     );
   }
   return context;

--- a/packages/react-chess-puzzle/src/hooks/useChessPuzzleContext.ts
+++ b/packages/react-chess-puzzle/src/hooks/useChessPuzzleContext.ts
@@ -9,7 +9,8 @@ export const useChessPuzzleContext = () => {
   const context = React.useContext(ChessPuzzleContext);
   if (!context) {
     throw new Error(
-      "useChessGameContext must be used within a ChessGameProvider",
+      "useChessPuzzleContext must be used within a ChessPuzzle component. " +
+        "Make sure your component is wrapped with <ChessPuzzle.Root> or ensure the ChessPuzzle component is properly rendered in the component tree.",
     );
   }
   return context;


### PR DESCRIPTION
## Summary
- Fix incorrect error message in `useChessPuzzleContext` that referenced `ChessGameProvider`
- Make error messages more descriptive and actionable by specifying the correct component usage
- Provide clear guidance on wrapping components with proper Root components

## Changes
- **ChessPuzzle**: Fixed error message to reference `ChessPuzzle component` and `<ChessPuzzle.Root>`
- **ChessGame**: Updated error message to reference `ChessGame component` and `<ChessGame.Root>`
- Both messages now provide actionable guidance for developers

## Test plan
- Error messages are now correctly named and provide clear guidance
- Developers will understand exactly which component they need to wrap their code with
- The error messages reflect the actual implementation (providers are in Root components)

Fixes #35