### PR TITLE
fix: handle sound playback errors gracefully (#41)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13057,21 +13057,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/tsup/node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/tsutils": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
@@ -13998,7 +13983,7 @@
     },
     "packages/react-chess-game": {
       "name": "@react-chess-tools/react-chess-game",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "chess.js": "^1.0.0-beta.8",
@@ -14017,10 +14002,10 @@
     },
     "packages/react-chess-puzzle": {
       "name": "@react-chess-tools/react-chess-puzzle",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
-        "@react-chess-tools/react-chess-game": "0.4.1",
+        "@react-chess-tools/react-chess-game": "0.4.2",
         "chess.js": "^1.0.0-beta.8",
         "lodash": "^4.17.21"
       },

--- a/packages/react-chess-game/src/components/ChessGame/parts/Board.tsx
+++ b/packages/react-chess-game/src/components/ChessGame/parts/Board.tsx
@@ -98,6 +98,7 @@ export const Board: React.FC<ChessGameProps> = ({ options = {} }) => {
 
   // Calculate square width for precise positioning
   const squareWidth = React.useMemo(() => {
+    if (typeof document === "undefined") return 80;
     const squareElement = document.querySelector(`[data-square]`);
     return squareElement?.getBoundingClientRect()?.width ?? 80;
   }, [promotionMove]);

--- a/packages/react-chess-game/src/hooks/useBoardSounds.ts
+++ b/packages/react-chess-game/src/hooks/useBoardSounds.ts
@@ -2,6 +2,14 @@ import { useEffect } from "react";
 import { useChessGameContext } from "./useChessGameContext";
 import { type Sound } from "../assets/sounds";
 
+const playSound = async (audioElement: HTMLAudioElement) => {
+  try {
+    await audioElement.play();
+  } catch (error) {
+    console.warn("Failed to play sound:", (error as Error).message);
+  }
+};
+
 export const useBoardSounds = (sounds: Record<Sound, HTMLAudioElement>) => {
   const {
     info: { lastMove, isCheckmate },
@@ -12,17 +20,18 @@ export const useBoardSounds = (sounds: Record<Sound, HTMLAudioElement>) => {
       return;
     }
 
-    if (isCheckmate) {
-      sounds.gameOver?.play();
+    if (isCheckmate && sounds.gameOver) {
+      playSound(sounds.gameOver);
       return;
     }
-    if (lastMove?.captured) {
-      sounds.capture?.play();
+
+    if (lastMove?.captured && sounds.capture) {
+      playSound(sounds.capture);
       return;
     }
-    if (lastMove) {
-      sounds.move?.play();
-      return;
+
+    if (lastMove && sounds.move) {
+      playSound(sounds.move);
     }
-  }, [lastMove]);
+  }, [lastMove, isCheckmate, sounds]);
 };


### PR DESCRIPTION
## Summary
- Added error handling for sound playback to fix uncaught NotAllowedError on first move
- Improved server-side rendering compatibility by checking for document availability

## Changes
- Added `playSound` helper function that catches and logs audio playback errors
- Updated `useBoardSounds` hook to use error-safe audio playback
- Fixed SSR compatibility issue in Board component by checking for document existence

## Test plan
- [x] Test playing sounds after user interaction works normally
- [x] Test that sound errors are caught and logged when browser blocks autoplay
- [x] Verify no uncaught errors in console on first move

Fixes #41