### PR TITLE
fix(react-chess-game): address audio system review findings

### DIFF
--- a/.changeset/audio-review-followups.md
+++ b/.changeset/audio-review-followups.md
@@ -1,0 +1,5 @@
+---
+"@react-chess-tools/react-chess-game": patch
+---
+
+fix: inline bundled audio as data URIs so default sounds work in consumer apps, restore deselection clicks not emitting illegal-move events, and skip replaying stale game events when Sounds mounts mid-game

--- a/packages/react-chess-game/src/components/ChessGame/parts/Board.tsx
+++ b/packages/react-chess-game/src/components/ChessGame/parts/Board.tsx
@@ -10,7 +10,7 @@ import {
   getCustomSquareStyles,
   deepMergeChessboardOptions,
 } from "../../../utils/board";
-import { requiresPromotion } from "../../../utils/chess";
+import { isLegalMove, requiresPromotion } from "../../../utils/chess";
 import { useChessGameBoardContainerContext } from "../../../hooks/useChessGameBoardContainerContext";
 import { useChessGameContext } from "../../../hooks/useChessGameContext";
 import { useChessGameTheme } from "../../../theme/context";
@@ -104,6 +104,18 @@ export const Board = React.forwardRef<HTMLDivElement, ChessGameProps>(
           return setActiveSquare(square);
         }
         return;
+      }
+
+      // Deselecting (clicking an unreachable square) is not an attempted
+      // move: it must not emit an illegal-move event
+      if (
+        !isLegalMove(game, {
+          from: activeSquare,
+          to: square,
+          promotion: "q",
+        })
+      ) {
+        return setActiveSquare(null);
       }
 
       if (

--- a/packages/react-chess-game/src/components/ChessGame/parts/__tests__/Board.test.tsx
+++ b/packages/react-chess-game/src/components/ChessGame/parts/__tests__/Board.test.tsx
@@ -3,6 +3,16 @@ import { fireEvent, render } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ChessGame } from "../..";
 import { Board } from "../Board";
+import { useChessGameContext } from "../../../../hooks/useChessGameContext";
+import type { ChessGameEvent } from "../../../../types/gameEvents";
+
+const GameEventProbe = ({ events }: { events: (ChessGameEvent | null)[] }) => {
+  const { gameEvent } = useChessGameContext();
+  React.useEffect(() => {
+    events.push(gameEvent);
+  }, [gameEvent, events]);
+  return null;
+};
 
 describe("ChessGame.Board", () => {
   it("should have correct displayName", () => {
@@ -121,6 +131,38 @@ describe("ChessGame.Board", () => {
     fireEvent.pointerDown(board);
 
     expect(document.activeElement).toBe(board);
+  });
+
+  it("should not emit an illegal-move event when a click deselects the piece", () => {
+    const events: (ChessGameEvent | null)[] = [];
+    const { container } = render(
+      <ChessGame.Root>
+        <Board />
+        <GameEventProbe events={events} />
+      </ChessGame.Root>,
+    );
+
+    fireEvent.click(container.querySelector('[data-square="e2"]')!);
+    fireEvent.click(container.querySelector('[data-square="d5"]')!);
+
+    expect(events.filter(Boolean)).toEqual([]);
+  });
+
+  it("should emit a move-made event when a legal move is played by click", () => {
+    const events: (ChessGameEvent | null)[] = [];
+    const { container } = render(
+      <ChessGame.Root>
+        <Board options={{ showAnimations: false }} />
+        <GameEventProbe events={events} />
+      </ChessGame.Root>,
+    );
+
+    fireEvent.click(container.querySelector('[data-square="e2"]')!);
+    fireEvent.click(container.querySelector('[data-square="e4"]')!);
+
+    const emitted = events.filter(Boolean) as ChessGameEvent[];
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({ type: "move-made" });
   });
 
   it("should throw error when used outside ChessGame.Root", () => {

--- a/packages/react-chess-game/src/hooks/useBoardSounds.test.ts
+++ b/packages/react-chess-game/src/hooks/useBoardSounds.test.ts
@@ -211,6 +211,36 @@ describe("useBoardSounds", () => {
     expect(mockPlay).toHaveBeenNthCalledWith(2, "move");
   });
 
+  it("should not replay an event that predates the mount", () => {
+    mockContextValue.gameEvent = {
+      id: 5,
+      type: "move-made",
+      fen: "fen",
+      isCheck: false,
+      isCheckmate: false,
+      isDraw: false,
+      move: { san: "e4", flags: "b" } as never,
+    };
+
+    const { rerender } = renderHook(() => useBoardSounds(sources));
+
+    expect(mockPlay).not.toHaveBeenCalled();
+
+    mockContextValue.gameEvent = {
+      id: 6,
+      type: "move-made",
+      fen: "fen-2",
+      isCheck: false,
+      isCheckmate: false,
+      isDraw: false,
+      move: { san: "e5", flags: "b" } as never,
+    };
+    rerender();
+
+    expect(mockPlay).toHaveBeenCalledTimes(1);
+    expect(mockPlay).toHaveBeenCalledWith("move");
+  });
+
   it("should destroy the audio manager on unmount", () => {
     const { unmount } = renderHook(() => useBoardSounds(sources));
 

--- a/packages/react-chess-game/src/hooks/useBoardSounds.ts
+++ b/packages/react-chess-game/src/hooks/useBoardSounds.ts
@@ -49,6 +49,8 @@ const getAudioEventForGameEvent = (
 export const useBoardSounds = (sources: ResolvedAudioSources) => {
   const { gameEvent } = useChessGameContext();
   const audioManagerRef = useRef<AudioManager | null>(null);
+  // Events emitted before mount must not replay when the hook mounts mid-game
+  const lastHandledEventIdRef = useRef(gameEvent?.id ?? null);
 
   useEffect(() => {
     const audioManager = createAudioManager(sources);
@@ -64,10 +66,11 @@ export const useBoardSounds = (sources: ResolvedAudioSources) => {
   }, [sources]);
 
   useEffect(() => {
-    if (!gameEvent) {
+    if (!gameEvent || gameEvent.id === lastHandledEventIdRef.current) {
       return;
     }
 
+    lastHandledEventIdRef.current = gameEvent.id;
     audioManagerRef.current?.play(getAudioEventForGameEvent(gameEvent));
   }, [gameEvent]);
 };

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   external: ["react", "react-dom"],
   dts: true,
   loader: {
-    ".ogg": "file",
+    ".ogg": "dataurl",
   },
 });


### PR DESCRIPTION
## Summary

Follow-ups from the post-merge review of #81:

- **Bundled sounds were broken for consumers (blocker)**: the tsup `file` loader emitted page-relative paths like `./capture-XXXX.ogg` in the published JS, which resolve against the consumer's page URL and 404 silently, so default sounds never played outside this repo's Storybook. Switched to the `dataurl` loader: assets are inlined as base64 data URIs (~30KB total), matching the pre-#81 inline approach.
- **Spurious `illegal-move` events**: restored the `isLegalMove` guard in the Board click handler, so clicking an unreachable square to deselect a piece no longer goes through `makeMove` and no longer emits an `illegal-move` event on the new `gameEvent` stream.
- **Stale event replay**: `useBoardSounds` now tracks the last handled event id, so mounting `ChessGame.Sounds` mid-game (e.g. a sound on/off toggle) doesn't replay the latest move's sound.

## Test plan

- [x] New test: mounting Sounds with a pre-existing game event doesn't play it, later events do
- [x] New tests: click-deselection emits no game event, a legal click move emits `move-made`
- [x] Full suite (728 tests), lint, type check, and build pass
- [x] Verified `dist/index.js` inlines audio as `data:application/ogg;base64,...` with no loose .ogg files

🤖 Generated with [Claude Code](https://claude.com/claude-code)