### PR TITLE
fix(react-chess-game): board stuck on old position after puzzle change mid-animation

### DIFF
--- a/.changeset/promotion-flicker-fix.md
+++ b/.changeset/promotion-flicker-fix.md
@@ -1,0 +1,5 @@
+---
+"@react-chess-tools/react-chess-game": patch
+---
+
+Fix the board replaying the previous position when a new position is loaded while a move animation is still in flight (e.g. solving a puzzle with a promotion move and immediately loading the next puzzle, #83). The board now remounts when a new position is loaded, discarding stale animation timers.

--- a/packages/react-chess-game/src/components/ChessGame/parts/Board.tsx
+++ b/packages/react-chess-game/src/components/ChessGame/parts/Board.tsx
@@ -46,6 +46,7 @@ export const Board = React.forwardRef<HTMLDivElement, ChessGameProps>(
       orientation,
       info,
       isLatestMove,
+      positionId,
       methods: { makeMove },
     } = gameContext;
 
@@ -250,7 +251,10 @@ export const Board = React.forwardRef<HTMLDivElement, ChessGameProps>(
         onPointerDownCapture={handlePointerDownCapture}
         {...rest}
       >
-        <Chessboard options={mergedOptions} />
+        {/* Remounting on positionId discards react-chessboard's in-flight
+            animation timers, which would otherwise replay the previous
+            position over a newly loaded one (#83) */}
+        <Chessboard key={positionId} options={mergedOptions} />
         {promotionMove && (
           <>
             {/* Backdrop overlay - click to cancel */}

--- a/packages/react-chess-game/src/hooks/__tests__/useChessGame.test.tsx
+++ b/packages/react-chess-game/src/hooks/__tests__/useChessGame.test.tsx
@@ -55,6 +55,34 @@ describe("useChessGame", () => {
       expect(result.current.orientation).toBe("b");
     });
 
+    it("should change positionId when a position is loaded, but not on moves", () => {
+      const initialFen =
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+      const newFen =
+        "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2";
+
+      const { result, rerender } = renderHook(
+        ({ fen }) => useChessGame({ fen }),
+        { initialProps: { fen: initialFen } },
+      );
+
+      const initialPositionId = result.current.positionId;
+
+      act(() => {
+        result.current.methods.makeMove("e4");
+      });
+      expect(result.current.positionId).toBe(initialPositionId);
+
+      rerender({ fen: newFen });
+      expect(result.current.positionId).not.toBe(initialPositionId);
+
+      const afterFenChange = result.current.positionId;
+      act(() => {
+        result.current.methods.setPosition(initialFen, "w");
+      });
+      expect(result.current.positionId).not.toBe(afterFenChange);
+    });
+
     it("should not change orientation when prop is undefined on rerender", () => {
       const { result, rerender } = renderHook(
         ({ orientation }) => useChessGame({ orientation }),

--- a/packages/react-chess-game/src/hooks/useChessGame.ts
+++ b/packages/react-chess-game/src/hooks/useChessGame.ts
@@ -47,6 +47,10 @@ export const useChessGame = ({
   const [currentMoveIndex, setCurrentMoveIndex] = React.useState(-1);
   const [gameEvent, setGameEvent] = React.useState<ChessGameEvent | null>(null);
   const gameEventIdRef = React.useRef(0);
+  // Incremented every time a new position is loaded (fen prop change or
+  // setPosition), but not on moves. Consumers can key the board on it to
+  // discard in-flight move animations that would replay over the new position
+  const [positionId, setPositionId] = React.useState(0);
 
   // Sync game state when fen prop changes (skip on mount to avoid double initialization)
   useEffect(() => {
@@ -59,11 +63,13 @@ export const useChessGame = ({
       setInitialFen(fen);
       setGame(newGame);
       setCurrentMoveIndex(-1); // Reset move navigation when position changes externally
+      setPositionId((id) => id + 1);
     } catch (e) {
       console.error("Invalid FEN:", fen, e);
       setInitialFen(undefined);
       setGame(new Chess());
       setCurrentMoveIndex(-1);
+      setPositionId((id) => id + 1);
     }
   }, [fen]);
 
@@ -148,6 +154,7 @@ export const useChessGame = ({
       setOrientation(orientation);
       setGame(newGame);
       setCurrentMoveIndex(-1);
+      setPositionId((id) => id + 1);
     } catch (e) {
       console.error("Failed to load FEN:", fen, e);
     }
@@ -259,6 +266,7 @@ export const useChessGame = ({
     orientation,
     currentMoveIndex,
     isLatestMove,
+    positionId,
     info,
     gameEvent,
     methods,

--- a/packages/react-chess-puzzle/src/__tests__/promotionAnimationFlicker.test.tsx
+++ b/packages/react-chess-puzzle/src/__tests__/promotionAnimationFlicker.test.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  useChessGameContext,
+  ChessGameContextType,
+} from "@react-chess-tools/react-chess-game";
+import { ChessPuzzle } from "../components/ChessPuzzle";
+import type { Puzzle } from "../utils";
+
+// Repro for https://github.com/dancamma/react-chess-tools/issues/82 follow-up
+// issue #83: solving a puzzle with a promotion move starts a 300ms animation
+// inside react-chessboard; when onSolve immediately swaps the puzzle, the
+// stale animation timer used to reapply the previous puzzle's position over
+// the new one
+const puzzles: Puzzle[] = [
+  {
+    fen: "8/3P4/6p1/4p3/4Pk1p/5P1P/3K4/r7 w - - 0 51",
+    moves: ["d7d8q"],
+    makeFirstMove: false,
+  },
+  {
+    fen: "8/1P6/2K4k/7p/8/8/5r2/8 w - - 0 55",
+    moves: ["b7b8q"],
+    makeFirstMove: false,
+  },
+];
+
+const contexts: { game: ChessGameContextType | null } = { game: null };
+
+const ContextProbe = () => {
+  contexts.game = useChessGameContext();
+  return null;
+};
+
+const PuzzleSolver = () => {
+  const [currentPuzzle, setCurrentPuzzle] = React.useState(0);
+
+  return (
+    <ChessPuzzle.Root
+      puzzle={puzzles[currentPuzzle]}
+      onSolve={() => setCurrentPuzzle((prev) => (prev + 1) % puzzles.length)}
+    >
+      <ChessPuzzle.Board />
+      <ContextProbe />
+    </ChessPuzzle.Root>
+  );
+};
+
+const pieceOn = (square: string) =>
+  document
+    .querySelector(`[data-square="${square}"] [data-piece]`)
+    ?.getAttribute("data-piece");
+
+describe("promotion animation on puzzle change", () => {
+  beforeEach(() => {
+    contexts.game = null;
+    jest.useFakeTimers();
+    // jsdom has no layout: give squares a size so react-chessboard animates
+    jest
+      .spyOn(Element.prototype, "getBoundingClientRect")
+      .mockReturnValue(new DOMRect(0, 0, 80, 80));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("should not replay the solved position after the puzzle has changed", () => {
+    render(<PuzzleSolver />);
+
+    expect(pieceOn("d7")).toBe("wP");
+
+    // solving move: promotion, which react-chessboard animates over 300ms
+    act(() => {
+      contexts.game!.methods.makeMove({ from: "d7", to: "d8", promotion: "q" });
+    });
+
+    // onSolve already swapped in the second puzzle
+    expect(contexts.game!.currentFen).toBe(puzzles[1].fen);
+    expect(pieceOn("b7")).toBe("wP");
+
+    // once the stale animation timer fires, the board must still show the
+    // second puzzle, not the first puzzle's promoted queen
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(pieceOn("b7")).toBe("wP");
+    expect(pieceOn("f2")).toBe("bR");
+    expect(pieceOn("d8")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Context

Issue #83 reports that `onSolve` fires before the promotion animation finishes: if the consumer swaps the puzzle in `onSolve`, the board flickers back to the old state.

## Diagnosis (verified in a real browser via Storybook + Playwright)

Reproduced on main, and it's worse than a flicker: sampling the DOM after the solving promotion move, the board shows the new puzzle at t≈40ms but at t≈330ms it **goes back to the old puzzle (queen on d8) and stays there**.

The root cause is in react-chessboard v5: the branch that animates promotions registers a `setTimeout(300ms)` that reapplies the destination position, and never clears it when the position changes again (it does `return` without a cleanup). Our puzzle switch arrives with `animationDurationInMs: 0`, so its timer fires immediately and the stale promotion timer then overwrites everything.

## Fix

As suggested in the issue ("if the board has changed then the animation shouldn't take place"):

- `useChessGame` exposes a `positionId`, incremented only when a new position is loaded (`fen` prop change or `setPosition`), never on moves
- `Board` uses `key={positionId}` on the `<Chessboard>`: on position change the board remounts cleanly and stale timers die with the unmounted instance

This also covers resetting the same puzzle mid-animation, not just puzzle changes.

## Verification

- Browser repro (Storybook + Playwright): with the fix the board switches to the new puzzle and stays there; regular move animations still play (`transition: transform 300ms` present on e2-e4)
- jsdom regression test (`promotionAnimationFlicker.test.tsx`): fails without the fix, passes with it
- Unit test for the `positionId` contract
- 727 tests, lint, tsc and build all green

The upstream react-chessboard bug (uncleared timeout in the promotion branch) deserves a separate report.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)