### PR TITLE
fix: correct history review, clock periods, puzzle lock, and engine stop race

### DIFF
--- a/.changeset/thermos-correctness-fixes.md
+++ b/.changeset/thermos-correctness-fixes.md
@@ -6,4 +6,6 @@
 "@react-chess-tools/react-chess-bot": patch
 ---
 
-Fix several correctness bugs: history review at the start position can no longer append live moves; a cancelled Stockfish search no longer swallows the next bestmove; puzzles lock after solve/fail and during CPU ply; a clock flag freezes the board and bot; multi-period increment/delay follow the current period; addTime while running no longer refunds elapsed time.
+Fix several correctness bugs: history review at the start position can no longer append live moves; a cancelled Stockfish search no longer swallows the next bestmove; puzzles lock after solve/fail and during CPU ply; a clock flag freezes the board and bot; multi-period increment/delay follow the current period; addTime no longer refunds elapsed time while running or paused, and no longer decays after a flag.
+
+Note two consumer-visible changes in `react-chess-game`: `isLatestMove` now returns `false` at the start position when history exists (it previously returned `true`), and the game context exposes a new `isPlayable` field that gates board interaction.

--- a/.changeset/thermos-correctness-fixes.md
+++ b/.changeset/thermos-correctness-fixes.md
@@ -1,0 +1,9 @@
+---
+"@react-chess-tools/react-chess-game": patch
+"@react-chess-tools/react-chess-clock": patch
+"@react-chess-tools/react-chess-puzzle": patch
+"@react-chess-tools/react-chess-stockfish": patch
+"@react-chess-tools/react-chess-bot": patch
+---
+
+Fix several correctness bugs: history review at the start position can no longer append live moves; a cancelled Stockfish search no longer swallows the next bestmove; puzzles lock after solve/fail and during CPU ply; a clock flag freezes the board and bot; multi-period increment/delay follow the current period; addTime while running no longer refunds elapsed time.

--- a/packages/react-chess-bot/src/components/ChessBot/parts/Player.tsx
+++ b/packages/react-chess-bot/src/components/ChessBot/parts/Player.tsx
@@ -59,7 +59,7 @@ interface DelayedMove {
 interface RuntimeContext {
   currentFen: string;
   isLatestMove: boolean;
-  isGameOver: boolean;
+  isPlayable: boolean;
   turn: Color;
   paused: boolean;
   autoPlay: boolean;
@@ -119,7 +119,7 @@ export const Player: React.FC<PlayerProps> = ({
   onMove,
   onError,
 }) => {
-  const { game, currentFen, info, isLatestMove, methods } =
+  const { game, currentFen, isLatestMove, isPlayable, methods } =
     useChessGameContext();
 
   const resolvedStrength = React.useMemo(
@@ -178,7 +178,7 @@ export const Player: React.FC<PlayerProps> = ({
   const runtimeContextRef = React.useRef<RuntimeContext>({
     currentFen,
     isLatestMove,
-    isGameOver: info.isGameOver,
+    isPlayable,
     turn: game.turn(),
     paused,
     autoPlay,
@@ -188,7 +188,7 @@ export const Player: React.FC<PlayerProps> = ({
   runtimeContextRef.current = {
     currentFen,
     isLatestMove,
-    isGameOver: info.isGameOver,
+    isPlayable,
     turn: game.turn(),
     paused,
     autoPlay,
@@ -292,7 +292,7 @@ export const Player: React.FC<PlayerProps> = ({
         runtimeContext.paused ||
         !runtimeContext.autoPlay ||
         !runtimeContext.isLatestMove ||
-        runtimeContext.isGameOver ||
+        !runtimeContext.isPlayable ||
         runtimeContext.currentFen !== move.fenBefore ||
         runtimeContext.turn !== color
       ) {
@@ -555,7 +555,7 @@ export const Player: React.FC<PlayerProps> = ({
     }
 
     const canPlay =
-      !paused && autoPlay && isLatestMove && !info.isGameOver && isBotTurn;
+      !paused && autoPlay && isLatestMove && isPlayable && isBotTurn;
 
     if (!canPlay) {
       cancelPendingWork();
@@ -604,7 +604,7 @@ export const Player: React.FC<PlayerProps> = ({
     cancelPendingWork,
     color,
     currentFen,
-    info.isGameOver,
+    isPlayable,
     isBotTurn,
     isLatestMove,
     paused,

--- a/packages/react-chess-clock/src/hooks/__tests__/clockReducer.test.ts
+++ b/packages/react-chess-clock/src/hooks/__tests__/clockReducer.test.ts
@@ -404,6 +404,22 @@ describe("clockReducer", () => {
       });
       expect(state.moveStartTime).toBe(resumeTime);
     });
+
+    it("should keep moveStartTime when adding time while running", () => {
+      const startTime = 1000000;
+      const state = createState({
+        status: "running",
+        activePlayer: "white",
+        moveStartTime: startTime,
+      });
+      const result = clockReducer(state, {
+        type: "ADD_TIME",
+        payload: { player: "white", milliseconds: 5000, now: startTime + 2000 },
+      });
+
+      expect(result.times.white).toBe(305000);
+      expect(result.moveStartTime).toBe(startTime);
+    });
   });
 
   describe("SET_TIME", () => {
@@ -935,6 +951,32 @@ describe("clockReducer - multi-period time controls", () => {
       expect(result.periodState?.periodIndex).toEqual({ white: 1, black: 0 });
       expect(result.periodState?.periodMoves).toEqual({ white: 0, black: 1 });
     });
+
+    it("should add the next period's time when advancing during delayed mode", () => {
+      const periods = [
+        { baseTime: 300_000, increment: 5_000, moves: 1 },
+        { baseTime: 180_000, increment: 3_000 },
+      ];
+
+      const periodState = createPeriodState(
+        { white: 0, black: 0 },
+        { white: 0, black: 0 },
+        periods,
+      );
+
+      const state = createInitialClockState(
+        { white: 300000, black: 300000 },
+        "delayed",
+        null,
+        multiPeriodConfig,
+        periodState,
+      );
+
+      const result = clockReducer(state, { type: "SWITCH", payload: {} });
+
+      expect(result.periodState?.periodIndex.white).toBe(1);
+      expect(result.times.white).toBe(480000);
+    });
   });
 
   describe("RESET with multi-period state", () => {
@@ -980,6 +1022,23 @@ describe("clockReducer - multi-period time controls", () => {
       expect(result.activePlayer).toBeNull();
       expect(result.periodState?.periodIndex).toEqual({ white: 0, black: 0 });
       expect(result.periodState?.periodMoves).toEqual({ white: 0, black: 0 });
+    });
+
+    it("should not store period state for a one-period array", () => {
+      const state = createState({
+        status: "running",
+        activePlayer: "white",
+      });
+
+      const result = clockReducer(state, {
+        type: "RESET",
+        payload: {
+          time: [{ baseTime: 300, increment: 5 }],
+          clockStart: "delayed",
+        },
+      });
+
+      expect(result.periodState).toBeUndefined();
     });
   });
 });

--- a/packages/react-chess-clock/src/hooks/__tests__/clockReducer.test.ts
+++ b/packages/react-chess-clock/src/hooks/__tests__/clockReducer.test.ts
@@ -342,7 +342,7 @@ describe("clockReducer", () => {
       expect(result.times.black).toBe(250000);
     });
 
-    it("should reset elapsedAtPause when adding time to active player while paused", () => {
+    it("should keep elapsedAtPause when adding time to active player while paused", () => {
       const state = createState({
         status: "paused",
         activePlayer: "white",
@@ -353,8 +353,10 @@ describe("clockReducer", () => {
         payload: { player: "white", milliseconds: 5000 },
       });
 
+      // Time already spent on the move still counts: zeroing elapsedAtPause
+      // would refund it on resume.
       expect(result.times.white).toBe(305000);
-      expect(result.elapsedAtPause).toBe(0);
+      expect(result.elapsedAtPause).toBe(2000);
     });
 
     it("should not reset elapsedAtPause when adding time to non-active player while paused", () => {
@@ -389,20 +391,43 @@ describe("clockReducer", () => {
       });
       expect(state.elapsedAtPause).toBe(2000);
 
-      // Add 5 seconds while paused
+      // Add 5 seconds while paused - the 2s already spent must not be refunded
       state = clockReducer(state, {
         type: "ADD_TIME",
         payload: { player: "white", milliseconds: 5000 },
       });
-      expect(state.elapsedAtPause).toBe(0);
+      expect(state.times.white).toBe(305000);
+      expect(state.elapsedAtPause).toBe(2000);
 
-      // Resume - moveStartTime should equal now (no stale offset)
+      // Resume - elapsed offset carries over so display shows 303000, not 305000
       const resumeTime = pauseTime + 1000;
       state = clockReducer(state, {
         type: "RESUME",
         payload: { now: resumeTime },
       });
-      expect(state.moveStartTime).toBe(resumeTime);
+      expect(state.moveStartTime).toBe(resumeTime - 2000);
+    });
+
+    it("should null moveStartTime when adding time after a timeout", () => {
+      let state = createState({
+        status: "running",
+        activePlayer: "white",
+        moveStartTime: 1000000,
+      });
+      state = clockReducer(state, {
+        type: "TIMEOUT",
+        payload: { player: "white" },
+      });
+      expect(state.moveStartTime).toBe(1000000);
+
+      state = clockReducer(state, {
+        type: "ADD_TIME",
+        payload: { player: "white", milliseconds: 30000 },
+      });
+
+      // A stale moveStartTime would keep eating the added time in the display
+      expect(state.moveStartTime).toBeNull();
+      expect(state.times.white).toBe(30000);
     });
 
     it("should keep moveStartTime when adding time while running", () => {

--- a/packages/react-chess-clock/src/hooks/__tests__/useChessClock.test.tsx
+++ b/packages/react-chess-clock/src/hooks/__tests__/useChessClock.test.tsx
@@ -936,6 +936,33 @@ describe("useChessClock - multi-period time controls", () => {
       expect(result.current.times.white).toBe(whiteTimeAfterAdvance + 3_000);
     });
 
+    it("should not inherit period 1's increment in a period that declares none", () => {
+      const { result } = renderHook(() =>
+        useChessClock({
+          time: [{ baseTime: 300, increment: 5, moves: 1 }, { baseTime: 180 }],
+          timingMethod: "fischer",
+          clockStart: "immediate",
+        }),
+      );
+
+      act(() => {
+        result.current.methods.switch();
+      });
+
+      expect(result.current.currentPeriodIndex.white).toBe(1);
+      const whiteTimeAfterAdvance = result.current.times.white;
+
+      act(() => {
+        result.current.methods.switch();
+      });
+      act(() => {
+        result.current.methods.switch();
+      });
+
+      // Period 1 has no increment: white's switch must not add period 0's 5s
+      expect(result.current.times.white).toBe(whiteTimeAfterAdvance);
+    });
+
     it("should handle both players advancing simultaneously", () => {
       const { result } = renderHook(() =>
         useChessClock({

--- a/packages/react-chess-clock/src/hooks/__tests__/useChessClock.test.tsx
+++ b/packages/react-chess-clock/src/hooks/__tests__/useChessClock.test.tsx
@@ -906,6 +906,36 @@ describe("useChessClock - multi-period time controls", () => {
       });
     });
 
+    it("should apply the current period increment after advancing", () => {
+      const { result } = renderHook(() =>
+        useChessClock({
+          time: [
+            { baseTime: 300, increment: 5, moves: 1 },
+            { baseTime: 180, increment: 3 },
+          ],
+          timingMethod: "fischer",
+          clockStart: "immediate",
+        }),
+      );
+
+      act(() => {
+        result.current.methods.switch();
+      });
+
+      expect(result.current.currentPeriodIndex.white).toBe(1);
+      const whiteTimeAfterAdvance = result.current.times.white;
+
+      act(() => {
+        result.current.methods.switch();
+      });
+      act(() => {
+        result.current.methods.switch();
+      });
+
+      // White's second switch is in period 1 (increment 3s), with no elapsed time
+      expect(result.current.times.white).toBe(whiteTimeAfterAdvance + 3_000);
+    });
+
     it("should handle both players advancing simultaneously", () => {
       const { result } = renderHook(() =>
         useChessClock({

--- a/packages/react-chess-clock/src/hooks/clockReducer.ts
+++ b/packages/react-chess-clock/src/hooks/clockReducer.ts
@@ -308,16 +308,16 @@ export function clockReducer(
         ...state.times,
         [player]: state.times[player] + milliseconds,
       };
-      // Keep moveStartTime so display interpolation continues from the existing
-      // move start. Resetting it while running refunds elapsed time.
-      // When paused and modifying the active player's time, reset elapsedAtPause
-      // so RESUME doesn't use a stale offset that ignores the time change.
-      const resetElapsed =
-        state.status === "paused" && player === state.activePlayer;
+      // While running, keep moveStartTime so display interpolation continues
+      // from the existing move start (resetting it would refund elapsed time).
+      // While paused, keep elapsedAtPause for the same reason: the time already
+      // spent on the move still counts after the addition.
+      // When not running, null moveStartTime so a stale timestamp (e.g. left
+      // by TIMEOUT) doesn't keep eating the added time in the display.
       return {
         ...state,
         times: newTimes,
-        ...(resetElapsed && { elapsedAtPause: 0 }),
+        moveStartTime: state.status === "running" ? state.moveStartTime : null,
       };
     }
 

--- a/packages/react-chess-clock/src/hooks/clockReducer.ts
+++ b/packages/react-chess-clock/src/hooks/clockReducer.ts
@@ -213,9 +213,11 @@ export function clockReducer(
         }
 
         // Check for period advancement
+        let delayedTimes = state.times;
         if (newPeriodState) {
           const advanced = maybeAdvancePeriod(state.times, newPeriodState);
           newPeriodState = advanced.periodState;
+          delayedTimes = advanced.times;
         }
 
         const newStateStatus = newCount >= 2 ? "running" : "delayed";
@@ -223,6 +225,7 @@ export function clockReducer(
         return {
           ...state,
           activePlayer: newPlayer,
+          times: delayedTimes,
           switchCount: newCount,
           status: newStateStatus,
           periodState: newPeriodState,
@@ -287,14 +290,7 @@ export function clockReducer(
       const initialTimes = getInitialTimes(config);
       const now = action.payload.now;
 
-      // Compute period state for multi-period time controls
-      const periodState: PeriodState | undefined = config.periods
-        ? {
-            periodIndex: { white: 0, black: 0 },
-            periodMoves: { white: 0, black: 0 },
-            periods: config.periods,
-          }
-        : undefined;
+      const periodState = buildPeriodState(config);
 
       return createInitialClockState(
         initialTimes,
@@ -308,12 +304,12 @@ export function clockReducer(
 
     case "ADD_TIME": {
       const { player, milliseconds } = action.payload;
-      const now = action.payload.now ?? Date.now();
       const newTimes = {
         ...state.times,
         [player]: state.times[player] + milliseconds,
       };
-      // Reset timing so display interpolation restarts from the new base time.
+      // Keep moveStartTime so display interpolation continues from the existing
+      // move start. Resetting it while running refunds elapsed time.
       // When paused and modifying the active player's time, reset elapsedAtPause
       // so RESUME doesn't use a stale offset that ignores the time change.
       const resetElapsed =
@@ -321,7 +317,6 @@ export function clockReducer(
       return {
         ...state,
         times: newTimes,
-        moveStartTime: state.status === "running" ? now : null,
         ...(resetElapsed && { elapsedAtPause: 0 }),
       };
     }
@@ -354,6 +349,24 @@ export function clockReducer(
 // ============================================================================
 // Initial State Factory
 // ============================================================================
+
+/**
+ * Period tracking is only stored when there are two or more periods.
+ * A one-period array is equivalent to a single-period control.
+ */
+export function buildPeriodState(
+  config: NormalizedTimeControl,
+): PeriodState | undefined {
+  if (!config.periods || config.periods.length <= 1) {
+    return undefined;
+  }
+
+  return {
+    periodIndex: { white: 0, black: 0 },
+    periodMoves: { white: 0, black: 0 },
+    periods: config.periods,
+  };
+}
 
 export function createInitialClockState(
   initialTimes: ClockTimes,

--- a/packages/react-chess-clock/src/hooks/useChessClock.ts
+++ b/packages/react-chess-clock/src/hooks/useChessClock.ts
@@ -11,6 +11,7 @@ import type {
   ClockInfo,
   ClockMethods,
   ClockTimes,
+  NormalizedTimeControl,
   PeriodState,
   TimeControlConfig,
   TimeControlInput,
@@ -23,12 +24,32 @@ import {
   getInitialActivePlayer,
   getInitialStatus,
 } from "../utils/timingMethods";
-import { clockReducer, createInitialClockState } from "./clockReducer";
+import {
+  clockReducer,
+  createInitialClockState,
+  buildPeriodState,
+} from "./clockReducer";
 
 /** Default config used internally when clock is disabled */
 const DISABLED_CLOCK_CONFIG: TimeControlConfig = {
   time: { baseTime: 0 },
 };
+
+function getPeriodTiming(
+  config: NormalizedTimeControl,
+  periodState: PeriodState | undefined,
+  player: ClockColor | null,
+): { increment: number; delay: number } {
+  if (!periodState || player === null) {
+    return { increment: config.increment, delay: config.delay };
+  }
+
+  const period = periodState.periods[periodState.periodIndex[player]];
+  return {
+    increment: period?.increment ?? config.increment,
+    delay: period?.delay ?? config.delay,
+  };
+}
 
 /**
  * Serializes time-relevant config for change detection.
@@ -97,15 +118,7 @@ export function useChessClock(options: TimeControlConfig): UseChessClockReturn {
     const initialConfig = parseTimeControlConfig(options);
     const initialTimesValue = getInitialTimes(initialConfig);
 
-    // Initialize period state for multi-period time controls
-    const initialPeriodState: PeriodState | undefined =
-      initialConfig.periods && initialConfig.periods.length > 1
-        ? {
-            periodIndex: { white: 0, black: 0 },
-            periodMoves: { white: 0, black: 0 },
-            periods: initialConfig.periods,
-          }
-        : undefined;
+    const initialPeriodState = buildPeriodState(initialConfig);
 
     return createInitialClockState(
       initialTimesValue,
@@ -157,7 +170,8 @@ export function useChessClock(options: TimeControlConfig): UseChessClockReturn {
             state.moveStartTime,
             state.elapsedAtPause,
             state.config.timingMethod,
-            state.config.delay,
+            getPeriodTiming(state.config, state.periodState, state.activePlayer)
+              .delay,
           ),
         };
 
@@ -261,12 +275,17 @@ export function useChessClock(options: TimeControlConfig): UseChessClockReturn {
     ) {
       const timeSpent = now - currentState.moveStartTime;
       const currentTime = currentState.times[currentState.activePlayer];
-
-      const newTime = calculateSwitchTime(
-        currentTime,
-        timeSpent,
+      const periodTiming = getPeriodTiming(
         currentState.config,
+        currentState.periodState,
+        currentState.activePlayer,
       );
+
+      const newTime = calculateSwitchTime(currentTime, timeSpent, {
+        ...currentState.config,
+        increment: periodTiming.increment,
+        delay: periodTiming.delay,
+      });
 
       newTimes = {
         ...currentState.times,

--- a/packages/react-chess-clock/src/hooks/useChessClock.ts
+++ b/packages/react-chess-clock/src/hooks/useChessClock.ts
@@ -44,10 +44,12 @@ function getPeriodTiming(
     return { increment: config.increment, delay: config.delay };
   }
 
+  // config.increment/delay mirror period 1's values, so falling back to them
+  // would leak period 1's timing into periods that declare none.
   const period = periodState.periods[periodState.periodIndex[player]];
   return {
-    increment: period?.increment ?? config.increment,
-    delay: period?.delay ?? config.delay,
+    increment: period?.increment ?? 0,
+    delay: period?.delay ?? 0,
   };
 }
 

--- a/packages/react-chess-game/src/components/ChessGame/parts/Board.tsx
+++ b/packages/react-chess-game/src/components/ChessGame/parts/Board.tsx
@@ -46,11 +46,12 @@ export const Board = React.forwardRef<HTMLDivElement, ChessGameProps>(
       orientation,
       info,
       isLatestMove,
+      isPlayable,
       positionId,
       methods: { makeMove },
     } = gameContext;
 
-    const { turn, isGameOver } = info;
+    const { turn } = info;
 
     const [activeSquare, setActiveSquare] = React.useState<Square | null>(null);
 
@@ -95,7 +96,7 @@ export const Board = React.forwardRef<HTMLDivElement, ChessGameProps>(
     const onSquareClick = (square: Square) => {
       focusBoardContainer();
 
-      if (isGameOver) {
+      if (!isPlayable) {
         return;
       }
 
@@ -204,7 +205,7 @@ export const Board = React.forwardRef<HTMLDivElement, ChessGameProps>(
       lightSquareStyle: theme.board.lightSquare,
       darkSquareStyle: theme.board.darkSquare,
       canDragPiece: ({ piece }) => {
-        if (isGameOver) return false;
+        if (!isPlayable) return false;
         return piece.pieceType[0] === turn;
       },
       dropSquareStyle: theme.state.dropSquare,

--- a/packages/react-chess-game/src/components/ChessGame/parts/Board.tsx
+++ b/packages/react-chess-game/src/components/ChessGame/parts/Board.tsx
@@ -96,7 +96,9 @@ export const Board = React.forwardRef<HTMLDivElement, ChessGameProps>(
     const onSquareClick = (square: Square) => {
       focusBoardContainer();
 
-      if (!isPlayable) {
+      // During history review the live game and the rendered position differ:
+      // selecting would paint legal-move dots for a position the user can't see
+      if (!isPlayable || !isLatestMove) {
         return;
       }
 
@@ -205,7 +207,7 @@ export const Board = React.forwardRef<HTMLDivElement, ChessGameProps>(
       lightSquareStyle: theme.board.lightSquare,
       darkSquareStyle: theme.board.darkSquare,
       canDragPiece: ({ piece }) => {
-        if (!isPlayable) return false;
+        if (!isPlayable || !isLatestMove) return false;
         return piece.pieceType[0] === turn;
       },
       dropSquareStyle: theme.state.dropSquare,

--- a/packages/react-chess-game/src/components/ChessGame/parts/__tests__/Board.test.tsx
+++ b/packages/react-chess-game/src/components/ChessGame/parts/__tests__/Board.test.tsx
@@ -165,6 +165,40 @@ describe("ChessGame.Board", () => {
     expect(emitted[0]).toMatchObject({ type: "move-made" });
   });
 
+  it("should not react to clicks while reviewing history", () => {
+    const events: (ChessGameEvent | null)[] = [];
+    const NavigateBack = () => {
+      const {
+        methods: { goToStart },
+        game,
+      } = useChessGameContext();
+      React.useEffect(() => {
+        if (game.history().length > 0) {
+          goToStart();
+        }
+      }, [game.history().length, goToStart]);
+      return null;
+    };
+
+    const { container } = render(
+      <ChessGame.Root>
+        <Board options={{ showAnimations: false }} />
+        <GameEventProbe events={events} />
+        <NavigateBack />
+      </ChessGame.Root>,
+    );
+
+    fireEvent.click(container.querySelector('[data-square="e2"]')!);
+    fireEvent.click(container.querySelector('[data-square="e4"]')!);
+    events.length = 0;
+
+    // Now at the start position in review mode: clicks must be inert
+    fireEvent.click(container.querySelector('[data-square="d2"]')!);
+    fireEvent.click(container.querySelector('[data-square="d4"]')!);
+
+    expect(events.filter(Boolean)).toEqual([]);
+  });
+
   it("should throw error when used outside ChessGame.Root", () => {
     // Suppress console.error for this test
     const consoleError = jest

--- a/packages/react-chess-game/src/hooks/__tests__/useChessGame.test.tsx
+++ b/packages/react-chess-game/src/hooks/__tests__/useChessGame.test.tsx
@@ -104,6 +104,7 @@ describe("useChessGame", () => {
     expect(result.current.orientation).toBe("w");
     expect(result.current.currentMoveIndex).toBe(-1);
     expect(result.current.isLatestMove).toBe(true);
+    expect(result.current.isPlayable).toBe(true);
     expect(result.current.info.turn).toBe("w");
   });
 
@@ -263,10 +264,28 @@ describe("useChessGame", () => {
       });
 
       expect(hookResult.result.current.currentMoveIndex).toBe(-1);
-      expect(hookResult.result.current.isLatestMove).toBe(true);
+      expect(hookResult.result.current.isLatestMove).toBe(false);
       expect(hookResult.result.current.currentFen).toContain(
         "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w",
       );
+    });
+
+    it("should not allow moves from the start position once history exists", () => {
+      act(() => {
+        hookResult.result.current.methods.goToStart();
+      });
+
+      act(() => {
+        const success = hookResult.result.current.methods.makeMove("e5");
+        expect(success).toBe(false);
+      });
+
+      expect(hookResult.result.current.game.history()).toEqual([
+        "e4",
+        "e5",
+        "Nf3",
+        "Nc6",
+      ]);
     });
 
     it("should go to the end position", () => {
@@ -510,6 +529,11 @@ describe("useChessGame", () => {
       expect(result.current.gameEvent).toMatchObject({
         type: "clock-timeout",
         player: "white",
+      });
+      expect(result.current.isPlayable).toBe(false);
+
+      act(() => {
+        expect(result.current.methods.makeMove("e4")).toBe(false);
       });
     });
   });

--- a/packages/react-chess-game/src/hooks/useChessGame.ts
+++ b/packages/react-chess-game/src/hooks/useChessGame.ts
@@ -81,8 +81,10 @@ export const useChessGame = ({
   }, [initialOrientation]);
 
   const history = React.useMemo(() => game.history(), [game]);
-  const isLatestMove =
-    currentMoveIndex === history.length - 1 || currentMoveIndex === -1;
+  // Empty history: length - 1 is -1, which matches the initial index.
+  // After moves, goToStart() writes -1 for the starting FEN — that is review,
+  // not the live position, so it must not count as latest.
+  const isLatestMove = currentMoveIndex === history.length - 1;
 
   const info = React.useMemo(
     () => getGameInfo(game, orientation),
@@ -97,6 +99,7 @@ export const useChessGame = ({
   const currentPosition = game.history()[currentMoveIndex];
 
   const clockState = useOptionalChessClock(timeControl);
+  const isPlayable = !info.isGameOver && (clockState?.timeout ?? null) === null;
 
   // Keep clockState in a ref to avoid re-creating makeMove on every clock tick.
   // The clock state object is recreated on every render (especially during active
@@ -266,6 +269,7 @@ export const useChessGame = ({
     orientation,
     currentMoveIndex,
     isLatestMove,
+    isPlayable,
     positionId,
     info,
     gameEvent,

--- a/packages/react-chess-puzzle/src/__tests__/puzzlePropChange.test.tsx
+++ b/packages/react-chess-puzzle/src/__tests__/puzzlePropChange.test.tsx
@@ -95,4 +95,33 @@ describe("ChessPuzzle.Root puzzle prop changes", () => {
     });
     await waitFor(() => expect(handleSolve).toHaveBeenCalledTimes(2));
   });
+
+  it("should make the CPU first move after switching between CPU-first puzzles", async () => {
+    const firstPuzzle: Puzzle = {
+      fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+      moves: ["e2e4"],
+      makeFirstMove: true,
+    };
+    const secondPuzzle: Puzzle = {
+      fen: "rnbqkbnr/pppp1ppp/8/4p3/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 2",
+      moves: ["g1f3"],
+      makeFirstMove: true,
+    };
+
+    const { rerender } = render(
+      <ChessPuzzle.Root puzzle={firstPuzzle}>
+        <ContextProbe />
+      </ChessPuzzle.Root>,
+    );
+
+    rerender(
+      <ChessPuzzle.Root puzzle={secondPuzzle}>
+        <ContextProbe />
+      </ChessPuzzle.Root>,
+    );
+
+    await waitFor(() => {
+      expect(contexts.game!.game.history()).toEqual(["Nf3"]);
+    });
+  });
 });

--- a/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/PuzzleBoard.tsx
+++ b/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/PuzzleBoard.tsx
@@ -39,17 +39,19 @@ export const PuzzleBoard = React.forwardRef<HTMLDivElement, PuzzleBoardProps>(
         stringToMove(game, nextMove),
         theme,
       ),
-      ...(!isPuzzlePlayable ? { canDragPiece: () => false } : {}),
+      // Block dragging and click-to-move without disabling pointer events:
+      // the board container must stay clickable so it can take focus for
+      // keyboard history review, and right-click arrows must keep working.
+      ...(!isPuzzlePlayable
+        ? { canDragPiece: () => false, onSquareClick: () => {} }
+        : {}),
     });
 
     return (
       <ChessGame.Board
         ref={ref}
         {...rest}
-        style={{
-          ...style,
-          ...(!isPuzzlePlayable ? { pointerEvents: "none" } : {}),
-        }}
+        style={style}
         options={mergedOptions}
       />
     );

--- a/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/PuzzleBoard.tsx
+++ b/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/PuzzleBoard.tsx
@@ -13,7 +13,7 @@ export interface PuzzleBoardProps extends React.ComponentProps<
 > {}
 
 export const PuzzleBoard = React.forwardRef<HTMLDivElement, PuzzleBoardProps>(
-  ({ options, ...rest }, ref) => {
+  ({ options, style, ...rest }, ref) => {
     const puzzleContext = useChessPuzzleContext();
     const gameContext = useChessGameContext();
     const theme = useChessPuzzleTheme();
@@ -27,6 +27,8 @@ export const PuzzleBoard = React.forwardRef<HTMLDivElement, PuzzleBoardProps>(
 
     const { game } = gameContext;
     const { status, hint, isPlayerTurn, nextMove } = puzzleContext;
+    const isPuzzlePlayable =
+      isPlayerTurn && (status === "not-started" || status === "in-progress");
 
     const mergedOptions = deepMergeChessboardOptions(options || {}, {
       squareStyles: getCustomSquareStyles(
@@ -37,9 +39,20 @@ export const PuzzleBoard = React.forwardRef<HTMLDivElement, PuzzleBoardProps>(
         stringToMove(game, nextMove),
         theme,
       ),
+      ...(!isPuzzlePlayable ? { canDragPiece: () => false } : {}),
     });
 
-    return <ChessGame.Board ref={ref} {...rest} options={mergedOptions} />;
+    return (
+      <ChessGame.Board
+        ref={ref}
+        {...rest}
+        style={{
+          ...style,
+          ...(!isPuzzlePlayable ? { pointerEvents: "none" } : {}),
+        }}
+        options={mergedOptions}
+      />
+    );
   },
 );
 

--- a/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/__tests__/PuzzleBoard.test.tsx
+++ b/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/__tests__/PuzzleBoard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ChessPuzzle } from "../..";
 import { PuzzleBoard } from "../PuzzleBoard";
@@ -16,7 +16,7 @@ describe("ChessPuzzle.PuzzleBoard", () => {
     expect(PuzzleBoard.displayName).toBe("ChessPuzzle.PuzzleBoard");
   });
 
-  it("should block interaction while waiting for the CPU first move", () => {
+  it("should block click-to-move while waiting for the CPU first move", () => {
     const cpuFirstPuzzle: Puzzle = {
       ...mockPuzzle,
       makeFirstMove: true,
@@ -28,8 +28,35 @@ describe("ChessPuzzle.PuzzleBoard", () => {
       </ChessPuzzle.Root>,
     );
 
-    const board = container.querySelector('[style*="position: relative"]');
-    expect(board).toHaveStyle({ pointerEvents: "none" });
+    fireEvent.click(container.querySelector('[data-square="e2"]')!);
+    fireEvent.click(container.querySelector('[data-square="e4"]')!);
+
+    expect(
+      container.querySelector('[data-square="e4"] [data-piece]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-square="e2"] [data-piece]'),
+    ).not.toBeNull();
+  });
+
+  it("should keep the board focusable while locked", () => {
+    const cpuFirstPuzzle: Puzzle = {
+      ...mockPuzzle,
+      makeFirstMove: true,
+    };
+
+    const { container } = render(
+      <ChessPuzzle.Root puzzle={cpuFirstPuzzle}>
+        <PuzzleBoard />
+      </ChessPuzzle.Root>,
+    );
+
+    const board = container.querySelector(
+      '[style*="position: relative"]',
+    ) as HTMLDivElement;
+    fireEvent.pointerDown(board);
+
+    expect(document.activeElement).toBe(board);
   });
 
   it("should forward ref to underlying Board component", () => {

--- a/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/__tests__/PuzzleBoard.test.tsx
+++ b/packages/react-chess-puzzle/src/components/ChessPuzzle/parts/__tests__/PuzzleBoard.test.tsx
@@ -16,6 +16,22 @@ describe("ChessPuzzle.PuzzleBoard", () => {
     expect(PuzzleBoard.displayName).toBe("ChessPuzzle.PuzzleBoard");
   });
 
+  it("should block interaction while waiting for the CPU first move", () => {
+    const cpuFirstPuzzle: Puzzle = {
+      ...mockPuzzle,
+      makeFirstMove: true,
+    };
+
+    const { container } = render(
+      <ChessPuzzle.Root puzzle={cpuFirstPuzzle}>
+        <PuzzleBoard />
+      </ChessPuzzle.Root>,
+    );
+
+    const board = container.querySelector('[style*="position: relative"]');
+    expect(board).toHaveStyle({ pointerEvents: "none" });
+  });
+
   it("should forward ref to underlying Board component", () => {
     const ref = React.createRef<HTMLDivElement>();
 

--- a/packages/react-chess-puzzle/src/hooks/__tests__/reducer.test.ts
+++ b/packages/react-chess-puzzle/src/hooks/__tests__/reducer.test.ts
@@ -230,6 +230,49 @@ describe("reducer", () => {
       expect(newState.isPlayerTurn).toBe(false);
     });
 
+    it("should ignore further player moves after the puzzle is failed", () => {
+      const failedState: State = {
+        ...initialState,
+        status: "failed",
+        nextMove: null,
+        isPlayerTurn: false,
+      };
+      const move = { san: "e4", lan: "e2e4" } as Move;
+
+      const newState = reducer(failedState, {
+        type: "PLAYER_MOVE",
+        payload: {
+          move,
+          puzzleContext: mockContext,
+          game,
+        },
+      });
+
+      expect(newState).toBe(failedState);
+    });
+
+    it("should ignore further player moves after the puzzle is solved", () => {
+      const solvedState: State = {
+        ...initialState,
+        status: "solved",
+        nextMove: null,
+        isPlayerTurn: false,
+        onSolveInvoked: true,
+      };
+      const move = { san: "d4", lan: "d2d4" } as Move;
+
+      const newState = reducer(solvedState, {
+        type: "PLAYER_MOVE",
+        payload: {
+          move,
+          puzzleContext: mockContext,
+          game,
+        },
+      });
+
+      expect(newState).toBe(solvedState);
+    });
+
     it("should handle solving the puzzle", () => {
       const move = { san: "Bb5", lan: "f1b5" } as Move;
 

--- a/packages/react-chess-puzzle/src/hooks/reducer.ts
+++ b/packages/react-chess-puzzle/src/hooks/reducer.ts
@@ -97,6 +97,10 @@ export const reducer = (state: State, action: Action): State => {
       };
 
     case "PLAYER_MOVE": {
+      if (state.status === "solved" || state.status === "failed") {
+        return state;
+      }
+
       const { move, game, solveOnCheckmate } = action.payload;
 
       if (move && solveOnCheckmate !== false && game.isCheckmate()) {

--- a/packages/react-chess-puzzle/src/hooks/useChessPuzzle.ts
+++ b/packages/react-chess-puzzle/src/hooks/useChessPuzzle.ts
@@ -53,7 +53,10 @@ export const useChessPuzzle = (
       }, 0);
       return () => clearTimeout(timeoutId);
     }
-  }, [gameContext, state.needCpuMove]);
+    // gameContext is a fresh object every render: keeping it in the deps
+    // would cancel and reschedule the pending timer on every re-render,
+    // which can starve the CPU first move under fast re-rendering.
+  }, [state.needCpuMove]);
 
   useEffect(() => {
     if (state.cpuMove) {

--- a/packages/react-chess-puzzle/src/hooks/useChessPuzzle.ts
+++ b/packages/react-chess-puzzle/src/hooks/useChessPuzzle.ts
@@ -46,13 +46,12 @@ export const useChessPuzzle = (
 
   useEffect(() => {
     if (gameContext && game.fen() === puzzle.fen && state.needCpuMove) {
-      setTimeout(
-        () =>
-          dispatch({
-            type: "CPU_MOVE",
-          }),
-        0,
-      );
+      const timeoutId = setTimeout(() => {
+        dispatch({
+          type: "CPU_MOVE",
+        });
+      }, 0);
+      return () => clearTimeout(timeoutId);
     }
   }, [gameContext, state.needCpuMove]);
 

--- a/packages/react-chess-puzzle/src/hooks/useChessPuzzle.ts
+++ b/packages/react-chess-puzzle/src/hooks/useChessPuzzle.ts
@@ -31,6 +31,7 @@ export const useChessPuzzle = (
     game,
     methods: { makeMove, setPosition },
   } = gameContext;
+  const gameFen = game.fen();
 
   const changePuzzle = useCallback(
     (puzzle: Puzzle) => {
@@ -45,7 +46,7 @@ export const useChessPuzzle = (
   }, [JSON.stringify(puzzle), changePuzzle]);
 
   useEffect(() => {
-    if (gameContext && game.fen() === puzzle.fen && state.needCpuMove) {
+    if (gameFen === puzzle.fen && state.needCpuMove) {
       const timeoutId = setTimeout(() => {
         dispatch({
           type: "CPU_MOVE",
@@ -53,10 +54,10 @@ export const useChessPuzzle = (
       }, 0);
       return () => clearTimeout(timeoutId);
     }
-    // gameContext is a fresh object every render: keeping it in the deps
-    // would cancel and reschedule the pending timer on every re-render,
-    // which can starve the CPU first move under fast re-rendering.
-  }, [state.needCpuMove]);
+    // Depend on stable position values rather than the fresh gameContext object.
+    // Both are needed so changing between CPU-first puzzles first cancels the old
+    // timer, then schedules a new one once the game has loaded the new FEN.
+  }, [gameFen, puzzle.fen, state.needCpuMove]);
 
   useEffect(() => {
     if (state.cpuMove) {

--- a/packages/react-chess-stockfish/src/engine/__tests__/stockfishEngine.test.ts
+++ b/packages/react-chess-stockfish/src/engine/__tests__/stockfishEngine.test.ts
@@ -793,6 +793,21 @@ describe("StockfishEngine", () => {
       expect(engine.getSnapshot().status).toBe("ready");
     });
 
+    it("does not swallow the next search's bestmove after a stale stop ack in ready", () => {
+      engine.stopAnalysis();
+      mockWorker.simulateMessage("bestmove e2e4");
+
+      const nextFen =
+        "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1";
+      engine.startAnalysis(nextFen);
+      mockWorker.simulateMessage("readyok");
+      mockWorker.simulateMessage("bestmove e7e5");
+
+      const snapshot = engine.getSnapshot();
+      expect(snapshot.status).toBe("ready");
+      expect(snapshot.isEngineThinking).toBe(false);
+    });
+
     it("ignores info lines after stop without crashing", () => {
       engine.stopAnalysis();
 

--- a/packages/react-chess-stockfish/src/engine/stockfishEngine.ts
+++ b/packages/react-chess-stockfish/src/engine/stockfishEngine.ts
@@ -816,6 +816,14 @@ export class StockfishEngine {
   private handleBestMove(line: string): void {
     if (this.engineState.type === "destroyed") return;
 
+    // Consume stale bestmoves from stopAnalysis even after we already
+    // transitioned to ready. Skipping only while analyzing left the counter
+    // stuck, so the next search's real bestmove was swallowed.
+    if (this.skipBestMoveCount > 0) {
+      this.skipBestMoveCount--;
+      return;
+    }
+
     const currentState = this.engineState;
 
     // Parse bestmove
@@ -852,11 +860,6 @@ export class StockfishEngine {
       }
     } else if (currentState.type === "analyzing") {
       // Natural completion (e.g., depth limit reached)
-      // Skip this bestmove if we're expecting to skip stale responses
-      if (this.skipBestMoveCount > 0) {
-        this.skipBestMoveCount--;
-        return;
-      }
       this.transition({ type: "ready" });
       this.mutableState.status = "ready";
       this.mutableState.isEngineThinking = false;


### PR DESCRIPTION
## Summary

Whole-repo correctness pass. These are user-visible defects, not a refactor.

- **History review:** `goToStart()` is no longer treated as the live position, so a drop at the starting FEN cannot append a move to the real game.
- **Stockfish stop:** a cancelled search consumes its stale `bestmove` even after the engine is already `ready`, so the next search can finish (the bot no longer stays thinking forever).
- **Puzzles:** extra moves after solve/fail are ignored; the board is not interactive during CPU ply or after a terminal status.
- **Clock flag:** timeout is treated as not playable, so the board freezes and the bot does not start a search that `makeMove` would reject.
- **Multi-period clocks:** increment and delay come from the current period; delayed `SWITCH` keeps the time added by period advancement; `addTime` while running no longer refunds elapsed time; `RESET` matches mount for one-period arrays.

`useChessGame` now exposes `isPlayable` (`!isGameOver` and no clock timeout). That is additive.

## Test plan

- [x] `npm test` — 740 tests
- [x] `npm run lint`
- [x] `npm run test-types`
- [ ] CI on this PR

Regression coverage added for: `goToStart` + `makeMove`, skip-counter leak, terminal `PLAYER_MOVE`, CPU-first puzzle lock, delayed period time, `ADD_TIME` while running, one-period `RESET`, period-1 increment, clock-timeout `isPlayable`.